### PR TITLE
Implement Ingenium home sections and copy

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,64 +1,44 @@
-import Image from "next/image";
+import { Audience } from "@/components/sections/Audience";
+import { Conditions } from "@/components/sections/Conditions";
+import { ContactCTA } from "@/components/sections/ContactCTA";
+import { Hero } from "@/components/sections/Hero";
+import { HowWeWork } from "@/components/sections/HowWeWork";
+import { Section } from "@/components/ui/Section";
+import { ingeniumCopy } from "@/content/ingenium.copy";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
+    <div className="min-h-screen bg-[#F6F0EA] text-stone-800">
+      <main>
+        <Section>
+          <Hero
+            brandName={ingeniumCopy.brand.name}
+            brandIntro={ingeniumCopy.brand.intro}
+            title={ingeniumCopy.hero.title}
+            subtitle={ingeniumCopy.hero.subtitle}
+            ctaPrimary={ingeniumCopy.hero.ctaPrimary}
+            ctaSecondary={ingeniumCopy.hero.ctaSecondary}
+          />
+        </Section>
+        <HowWeWork
+          title={ingeniumCopy.howWeWork.title}
+          items={ingeniumCopy.howWeWork.items}
         />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+        <Audience
+          title={ingeniumCopy.audience.title}
+          items={ingeniumCopy.audience.items}
+        />
+        <Conditions
+          title={ingeniumCopy.conditions.title}
+          bullets={ingeniumCopy.conditions.bullets}
+          disclaimer={ingeniumCopy.conditions.disclaimer}
+        />
+        <ContactCTA
+          title="Hablemos sobre tu consulta"
+          body="Podés escribirnos para coordinar una entrevista y conocer la propuesta. Respondemos con información clara y personalizada."
+          ctaLabel={ingeniumCopy.hero.ctaPrimary.label}
+          ctaHref={ingeniumCopy.hero.ctaPrimary.href}
+        />
       </main>
     </div>
   );

--- a/components/sections/Audience.tsx
+++ b/components/sections/Audience.tsx
@@ -1,0 +1,43 @@
+import { Section } from "@/components/ui/Section";
+
+type AudienceItem = {
+  title: string;
+  body: string;
+};
+
+type AudienceProps = {
+  title: string;
+  items: AudienceItem[];
+};
+
+export function Audience({ title, items }: AudienceProps) {
+  return (
+    <Section id="para-quien">
+      <div className="space-y-10">
+        <div className="text-center">
+          <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+            {title}
+          </h2>
+        </div>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {items.map((item) => (
+            <div
+              key={item.title}
+              className="overflow-hidden rounded-[26px] border border-white/70 bg-white/80 shadow-sm"
+            >
+              <div className="h-32 w-full bg-gradient-to-br from-[#f4dfc4] via-white/70 to-[#e8d6c1]" />
+              <div className="space-y-3 p-5">
+                <h3 className="text-lg font-semibold text-stone-900">
+                  {item.title}
+                </h3>
+                <p className="text-sm leading-relaxed text-stone-600">
+                  {item.body}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Conditions.tsx
+++ b/components/sections/Conditions.tsx
@@ -1,0 +1,32 @@
+import { Section } from "@/components/ui/Section";
+
+type ConditionsProps = {
+  title: string;
+  bullets: string[];
+  disclaimer: string;
+};
+
+export function Conditions({ title, bullets, disclaimer }: ConditionsProps) {
+  return (
+    <Section id="condiciones">
+      <div className="rounded-[30px] border border-white/70 bg-white/80 p-8 shadow-sm sm:p-10">
+        <div className="space-y-6">
+          <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+            {title}
+          </h2>
+          <ul className="space-y-3 text-sm leading-relaxed text-stone-600">
+            {bullets.map((bullet) => (
+              <li key={bullet} className="flex gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs leading-relaxed text-stone-500">
+            {disclaimer}
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -1,0 +1,36 @@
+import { Section } from "@/components/ui/Section";
+
+type ContactCTAProps = {
+  title: string;
+  body: string;
+  ctaLabel: string;
+  ctaHref: string;
+};
+
+export function ContactCTA({
+  title,
+  body,
+  ctaLabel,
+  ctaHref,
+}: ContactCTAProps) {
+  return (
+    <Section id="contacto" className="pb-24">
+      <div className="rounded-[32px] border border-white/70 bg-white/80 p-8 shadow-sm sm:p-12">
+        <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-3">
+            <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+              {title}
+            </h2>
+            <p className="text-sm leading-relaxed text-stone-600">{body}</p>
+          </div>
+          <a
+            href={ctaHref}
+            className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white transition hover:bg-[#a47a34] sm:w-auto"
+          >
+            {ctaLabel}
+          </a>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,0 +1,60 @@
+type HeroCta = {
+  label: string;
+  href: string;
+};
+
+type HeroProps = {
+  brandName: string;
+  brandIntro: string;
+  title: string;
+  subtitle: string;
+  ctaPrimary: HeroCta;
+  ctaSecondary: HeroCta;
+};
+
+export function Hero({
+  brandName,
+  brandIntro,
+  title,
+  subtitle,
+  ctaPrimary,
+  ctaSecondary,
+}: HeroProps) {
+  return (
+    <div className="rounded-[32px] border border-white/70 bg-white/80 p-8 shadow-sm sm:p-12">
+      <div className="grid items-center gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-6">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">
+              {brandName}
+            </p>
+            <h1 className="text-4xl font-semibold tracking-tight text-stone-900 sm:text-5xl">
+              {title}
+            </h1>
+            <p className="text-lg leading-relaxed text-stone-600">{subtitle}</p>
+          </div>
+          <p className="text-sm leading-relaxed text-stone-500">{brandIntro}</p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <a
+              href={ctaPrimary.href}
+              className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#a47a34] sm:w-auto"
+            >
+              {ctaPrimary.label}
+            </a>
+            <a
+              href={ctaSecondary.href}
+              className="inline-flex w-full items-center justify-center rounded-full border border-[#C9AE7C] bg-white px-5 py-3 text-sm font-semibold text-[#8C6A2B] transition hover:border-[#B88A3B] hover:text-[#6f521f] sm:w-auto"
+            >
+              {ctaSecondary.label}
+            </a>
+          </div>
+        </div>
+        <div className="relative">
+          <div className="flex aspect-[4/3] w-full items-center justify-center rounded-[28px] border border-white/60 bg-gradient-to-br from-[#f6e4cd] via-white/80 to-[#e7d4bb] text-sm font-medium text-stone-500 shadow-sm">
+            Imagen
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/HowWeWork.tsx
+++ b/components/sections/HowWeWork.tsx
@@ -1,0 +1,45 @@
+import { Section } from "@/components/ui/Section";
+
+type HowWeWorkItem = {
+  title: string;
+  body: string;
+};
+
+type HowWeWorkProps = {
+  title: string;
+  items: HowWeWorkItem[];
+};
+
+const icons = ["🌼", "💛", "✨"];
+
+export function HowWeWork({ title, items }: HowWeWorkProps) {
+  return (
+    <Section id="como-trabajamos">
+      <div className="space-y-10">
+        <div className="text-center">
+          <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+            {title}
+          </h2>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {items.map((item, index) => (
+            <div
+              key={item.title}
+              className="rounded-[28px] border border-white/70 bg-white/80 p-6 shadow-sm"
+            >
+              <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-[#F2E2CD] text-lg">
+                {icons[index] ?? "🌼"}
+              </div>
+              <h3 className="text-xl font-semibold text-stone-900">
+                {item.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-stone-600">
+                {item.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type SectionProps = {
+  id?: string;
+  className?: string;
+  children: ReactNode;
+};
+
+export function Section({ id, className, children }: SectionProps) {
+  return (
+    <section id={id} className={cn("w-full py-14 sm:py-20", className)}>
+      <div className="mx-auto w-full max-w-6xl px-6">{children}</div>
+    </section>
+  );
+}

--- a/content/ingenium.copy.ts
+++ b/content/ingenium.copy.ts
@@ -1,0 +1,73 @@
+export const ingeniumCopy = {
+  brand: {
+    name: "Ingenium",
+    tagline: "Un espacio para aprender a organizarse por dentro",
+    intro:
+      "Ingenium es un espacio educativo de acompañamiento integral, orientado a niños y adolescentes. Fortalece el aprendizaje desde una mirada multidisciplinaria, trabajando hábitos de estudio, organización personal, comprensión de procesos y bienestar emocional. Cada propuesta se adapta a las necesidades de cada estudiante, respetando sus tiempos, intereses y potencialidades.",
+  },
+  hero: {
+    title: "Un espacio para aprender a organizarse por dentro",
+    subtitle:
+      "Apoyo educativo desde una mirada multidisciplinaria para potenciar hábitos de estudio, gestión del tiempo y bienestar emocional.",
+    ctaPrimary: { label: "Consultar por WhatsApp", href: "#contacto" },
+    ctaSecondary: { label: "Coordinar una entrevista", href: "#contacto" },
+  },
+  howWeWork: {
+    title: "¿Cómo trabajamos?",
+    items: [
+      {
+        title: "Organización y hábitos",
+        body:
+          "Acompañamos al estudiante en la construcción de rutinas de estudio, planificación del tiempo y organización de tareas, priorizando estrategias que favorezcan la autonomía.",
+      },
+      {
+        title: "Comprensión y procesos",
+        body:
+          "Guiamos al alumno a comprender cómo aprende, aplicando diferentes estrategias para interpretar consignas, resolver problemas y afianzar contenidos escolares.",
+      },
+      {
+        title: "Acompañamiento emocional",
+        body:
+          "Brindamos contención socioemocional para fortalecer la autoestima, reducir el estrés académico y mejorar la relación con el aprendizaje.",
+      },
+    ],
+  },
+  audience: {
+    title: "¿Para quién es Ingenium?",
+    items: [
+      {
+        title: "Primaria",
+        body:
+          "Apoyo escolar con seguimiento personalizado, enfocado en afianzar contenidos y generar hábitos de estudio desde edades tempranas.",
+      },
+      {
+        title: "Secundaria",
+        body:
+          "Acompañamiento académico orientado a la organización, comprensión de contenidos y preparación para evaluaciones.",
+      },
+      {
+        title: "Recuperar la motivación",
+        body:
+          "Espacios pensados para estudiantes que han perdido el interés o la confianza en su proceso de aprendizaje.",
+      },
+      {
+        title: "Ayuda personalizada",
+        body:
+          "Intervenciones ajustadas a cada necesidad particular, combinando apoyo académico y emocional.",
+      },
+    ],
+  },
+  conditions: {
+    title: "Condiciones y marco de trabajo",
+    bullets: [
+      "Modalidad: presencial u online, según acuerdo previo.",
+      "Asistencia: las inasistencias deben avisarse con anticipación. Las clases no avisadas con antelación no son recuperables.",
+      "Pagos: los honorarios se acuerdan previamente y el pago se realiza de forma mensual.",
+      "Comunicación: el seguimiento se realiza en diálogo con las familias, priorizando una comunicación clara y respetuosa.",
+      "Marco: promovemos un espacio basado en respeto, tolerancia y confianza mutua.",
+      "Alcance: el acompañamiento no reemplaza tratamientos médicos ni terapéuticos cuando sean necesarios.",
+    ],
+    disclaimer:
+      "La información presentada es orientativa. Las condiciones completas del acompañamiento se acuerdan de manera personalizada al momento de la inscripción.",
+  },
+} as const;


### PR DESCRIPTION
### Motivation
- Replicar la maqueta warm/crema con acento dorado y cards redondeadas usando componentes simples y Tailwind.
- Centralizar el copy para la Home en un solo archivo importable para facilitar mantenimiento y revisión (`content/ingenium.copy.ts`).
- Estructurar la Home en secciones reutilizables para mantener la página prolija y mobile-first.
- Mantener cambios locales a la Home sin tocar routing ni dependencias nuevas.

### Description
- Añadido `content/ingenium.copy.ts` que exporta `ingeniumCopy` con el copy exacto provisto en la especificación.
- Nuevos componentes de sección: `components/sections/Hero.tsx`, `HowWeWork.tsx`, `Audience.tsx`, `Conditions.tsx`, `ContactCTA.tsx` y el wrapper `components/ui/Section.tsx` para spacing consistente.
- Reemplazada la implementación de `app/page.tsx` para componer las secciones con estilos Tailwind (fondo crema `#F6F0EA`, CTAs dorados `#B88A3B`, cards con bordes suaves y placeholders de imagen) y anchors solicitados (`#como-trabajamos`, `#para-quien`, `#condiciones`, `#contacto`).
- Se mantuvo el alcance limitado: no se añadieron librerías ni cambios globales de routing o layout.

### Testing
- Ejecutado `npm run dev -- --hostname 0.0.0.0 --port 3000`, el servidor de desarrollo arrancó y sirvió la página (`GET /` 200) aunque houve warnings por la descarga de Google Fonts.
- Capturada una captura de pantalla completa mediante un script automatizado de Playwright que finalizó correctamente y generó `artifacts/home.png`.
- Durante la compilación en modo desarrollo no se observaron errores de compilación o tipado que impidieran el renderizado de la Home.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c6177454832d92a7a9bdd480bb15)