### PR TITLE
Implement Ingenium home sections and copy

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,64 +1,18 @@
-import Image from "next/image";
+import Audience from "@/components/sections/Audience";
+import Conditions from "@/components/sections/Conditions";
+import ContactCTA from "@/components/sections/ContactCTA";
+import Hero from "@/components/sections/Hero";
+import HowWeWork from "@/components/sections/HowWeWork";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+    <div className="min-h-screen bg-[#F6F0EA] text-[#3f2f20]">
+      <main>
+        <Hero />
+        <HowWeWork />
+        <Audience />
+        <Conditions />
+        <ContactCTA />
       </main>
     </div>
   );

--- a/components/sections/Audience.tsx
+++ b/components/sections/Audience.tsx
@@ -6,7 +6,7 @@ export default function Audience() {
 
   return (
     <Section id="para-quien">
-      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.1)] backdrop-blur sm:p-12">
+      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
         <div className="space-y-10">
           <div className="text-center">
             <h2 className="text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
@@ -17,9 +17,9 @@ export default function Audience() {
             {audience.items.map((item) => (
               <div
                 key={item.title}
-                className="flex h-full flex-col gap-4 rounded-3xl border border-[#eadfce] bg-white/90 p-5 shadow-sm"
+                className="flex h-full flex-col gap-4 rounded-3xl border border-[#eadfce] bg-gradient-to-b from-white/95 via-white/90 to-[#fbf5ed] p-5 shadow-sm"
               >
-                <div className="h-32 w-full rounded-2xl bg-gradient-to-br from-[#f2ddbf] via-[#f7ead6] to-white" />
+                <div className="h-32 w-full rounded-2xl bg-gradient-to-br from-[#ecd2b0] via-[#f6e7d4] to-white shadow-[0_10px_30px_rgba(184,138,59,0.18)]" />
                 <div className="space-y-2">
                   <h3 className="text-lg font-semibold text-[#4a3725]">
                     {item.title}

--- a/components/sections/Audience.tsx
+++ b/components/sections/Audience.tsx
@@ -1,0 +1,38 @@
+import { ingeniumCopy } from "@/content/ingenium.copy";
+import Section from "@/components/ui/Section";
+
+export default function Audience() {
+  const { audience } = ingeniumCopy;
+
+  return (
+    <Section id="para-quien">
+      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.1)] backdrop-blur sm:p-12">
+        <div className="space-y-10">
+          <div className="text-center">
+            <h2 className="text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {audience.title}
+            </h2>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {audience.items.map((item) => (
+              <div
+                key={item.title}
+                className="flex h-full flex-col gap-4 rounded-3xl border border-[#eadfce] bg-white/90 p-5 shadow-sm"
+              >
+                <div className="h-32 w-full rounded-2xl bg-gradient-to-br from-[#f2ddbf] via-[#f7ead6] to-white" />
+                <div className="space-y-2">
+                  <h3 className="text-lg font-semibold text-[#4a3725]">
+                    {item.title}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                    {item.body}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Conditions.tsx
+++ b/components/sections/Conditions.tsx
@@ -1,0 +1,29 @@
+import { ingeniumCopy } from "@/content/ingenium.copy";
+import Section from "@/components/ui/Section";
+
+export default function Conditions() {
+  const { conditions } = ingeniumCopy;
+
+  return (
+    <Section id="condiciones">
+      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.1)] backdrop-blur sm:p-12">
+        <div className="space-y-6">
+          <h2 className="text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {conditions.title}
+          </h2>
+          <ul className="space-y-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {conditions.bullets.map((bullet) => (
+              <li key={bullet} className="flex gap-3">
+                <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs leading-relaxed text-[#7b6753] sm:text-sm">
+            {conditions.disclaimer}
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Conditions.tsx
+++ b/components/sections/Conditions.tsx
@@ -6,7 +6,7 @@ export default function Conditions() {
 
   return (
     <Section id="condiciones">
-      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.1)] backdrop-blur sm:p-12">
+      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
         <div className="space-y-6">
           <h2 className="text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
             {conditions.title}

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -6,10 +6,10 @@ export default function ContactCTA() {
 
   return (
     <Section id="contacto" className="pb-20">
-      <div className="rounded-[2.5rem] border border-[#eadfce] bg-gradient-to-br from-white/90 via-white/80 to-[#f7efe4] p-8 shadow-[0_12px_40px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
+      <div className="rounded-[2.75rem] border border-[#eadfce] bg-gradient-to-br from-white/90 via-white/80 to-[#f7efe4] p-8 shadow-[0_16px_50px_rgba(184,138,59,0.14)] backdrop-blur sm:p-12">
         <div className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
           <div className="space-y-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[#B88A3B]">
+            <p className="text-xs font-medium tracking-[0.3em] text-[#B88A3B]">
               {brand.name}
             </p>
             <h2 className="text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
@@ -20,7 +20,7 @@ export default function ContactCTA() {
               estudiante y proponer un plan de acompañamiento a medida.
             </p>
           </div>
-          <div className="space-y-4 rounded-3xl border border-[#eadfce] bg-white/80 p-6 text-left shadow-sm">
+          <div className="space-y-4 rounded-3xl border border-[#eadfce] bg-white/85 p-6 text-left shadow-sm">
             <p className="text-sm font-semibold text-[#4a3725]">
               Contacto
             </p>

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -1,0 +1,42 @@
+import { ingeniumCopy } from "@/content/ingenium.copy";
+import Section from "@/components/ui/Section";
+
+export default function ContactCTA() {
+  const { brand, hero } = ingeniumCopy;
+
+  return (
+    <Section id="contacto" className="pb-20">
+      <div className="rounded-[2.5rem] border border-[#eadfce] bg-gradient-to-br from-white/90 via-white/80 to-[#f7efe4] p-8 shadow-[0_12px_40px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
+        <div className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
+          <div className="space-y-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[#B88A3B]">
+              {brand.name}
+            </p>
+            <h2 className="text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {brand.tagline}
+            </h2>
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              Coordinemos una entrevista para conocer la situación de cada
+              estudiante y proponer un plan de acompañamiento a medida.
+            </p>
+          </div>
+          <div className="space-y-4 rounded-3xl border border-[#eadfce] bg-white/80 p-6 text-left shadow-sm">
+            <p className="text-sm font-semibold text-[#4a3725]">
+              Contacto
+            </p>
+            <p className="text-sm leading-relaxed text-[#6a5743]">
+              Dejanos tu consulta y nos pondremos en contacto para coordinar
+              disponibilidad, modalidad y objetivos de acompañamiento.
+            </p>
+            <a
+              href={hero.ctaPrimary.href}
+              className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/20 transition hover:translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+            >
+              {hero.ctaPrimary.label}
+            </a>
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -6,21 +6,21 @@ export default function Hero() {
 
   return (
     <Section className="pt-20 sm:pt-24">
-      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/75 p-8 shadow-[0_16px_50px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
-        <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+      <div className="rounded-[2.75rem] border border-[#eadfce] bg-gradient-to-br from-white/90 via-white/80 to-[#fbf5ed] p-8 shadow-[0_18px_60px_rgba(184,138,59,0.14)] backdrop-blur sm:p-12">
+        <div className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
           <div className="space-y-6">
             <div className="space-y-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[#B88A3B]">
+              <p className="text-xs font-medium tracking-[0.3em] text-[#B88A3B]">
                 {brand.name}
               </p>
-              <h1 className="text-3xl font-semibold tracking-tight text-[#3f2f20] sm:text-4xl lg:text-5xl">
+              <h1 className="text-balance text-3xl font-semibold tracking-tight text-[#3f2f20] sm:text-4xl lg:text-5xl">
                 {hero.title}
               </h1>
-              <p className="text-base leading-relaxed text-[#5c4a36] sm:text-lg">
+              <p className="text-pretty text-base leading-relaxed text-[#5c4a36] sm:text-lg">
                 {hero.subtitle}
               </p>
             </div>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            <p className="text-pretty text-sm leading-relaxed text-[#6a5743] sm:text-base">
               {brand.intro}
             </p>
             <div className="flex flex-col gap-3 sm:flex-row">
@@ -32,14 +32,14 @@ export default function Hero() {
               </a>
               <a
                 href={hero.ctaSecondary.href}
-                className="inline-flex w-full items-center justify-center rounded-full border border-[#d9c3a1] bg-white/70 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:translate-y-0.5 hover:border-[#cfae7a] sm:w-auto sm:text-base"
+                className="inline-flex w-full items-center justify-center rounded-full border border-[#d9c3a1] bg-white/80 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:translate-y-0.5 hover:border-[#cfae7a] sm:w-auto sm:text-base"
               >
                 {hero.ctaSecondary.label}
               </a>
             </div>
           </div>
           <div className="relative">
-            <div className="flex aspect-[4/3] items-center justify-center rounded-[2.5rem] border border-[#eadfce] bg-gradient-to-br from-[#f2ddbf] via-[#f7ead6] to-white text-sm font-semibold uppercase tracking-[0.2em] text-[#b58a44]">
+            <div className="flex aspect-[4/3] items-center justify-center rounded-[2.5rem] border border-[#eadfce] bg-gradient-to-br from-[#f2ddbf] via-[#f7ead6] to-white text-xs font-semibold uppercase tracking-[0.3em] text-[#b58a44]">
               Imagen
             </div>
           </div>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,0 +1,50 @@
+import { ingeniumCopy } from "@/content/ingenium.copy";
+import Section from "@/components/ui/Section";
+
+export default function Hero() {
+  const { brand, hero } = ingeniumCopy;
+
+  return (
+    <Section className="pt-20 sm:pt-24">
+      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/75 p-8 shadow-[0_16px_50px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
+        <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+          <div className="space-y-6">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[#B88A3B]">
+                {brand.name}
+              </p>
+              <h1 className="text-3xl font-semibold tracking-tight text-[#3f2f20] sm:text-4xl lg:text-5xl">
+                {hero.title}
+              </h1>
+              <p className="text-base leading-relaxed text-[#5c4a36] sm:text-lg">
+                {hero.subtitle}
+              </p>
+            </div>
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {brand.intro}
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <a
+                href={hero.ctaPrimary.href}
+                className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/20 transition hover:translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+              >
+                {hero.ctaPrimary.label}
+              </a>
+              <a
+                href={hero.ctaSecondary.href}
+                className="inline-flex w-full items-center justify-center rounded-full border border-[#d9c3a1] bg-white/70 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:translate-y-0.5 hover:border-[#cfae7a] sm:w-auto sm:text-base"
+              >
+                {hero.ctaSecondary.label}
+              </a>
+            </div>
+          </div>
+          <div className="relative">
+            <div className="flex aspect-[4/3] items-center justify-center rounded-[2.5rem] border border-[#eadfce] bg-gradient-to-br from-[#f2ddbf] via-[#f7ead6] to-white text-sm font-semibold uppercase tracking-[0.2em] text-[#b58a44]">
+              Imagen
+            </div>
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/HowWeWork.tsx
+++ b/components/sections/HowWeWork.tsx
@@ -8,7 +8,7 @@ export default function HowWeWork() {
 
   return (
     <Section id="como-trabajamos">
-      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.1)] backdrop-blur sm:p-12">
+      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
         <div className="space-y-10">
           <div className="text-center">
             <h2 className="text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
@@ -19,9 +19,9 @@ export default function HowWeWork() {
             {howWeWork.items.map((item, index) => (
               <div
                 key={item.title}
-                className="flex h-full flex-col gap-4 rounded-3xl border border-[#eadfce] bg-white/90 p-6 text-left shadow-sm"
+                className="flex h-full flex-col gap-4 rounded-3xl border border-[#eadfce] bg-gradient-to-b from-white/90 via-white/90 to-[#fbf5ed] p-6 text-center shadow-sm"
               >
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#f4e6d4] text-xl">
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[#f4e6d4] text-xl shadow-[0_6px_16px_rgba(184,138,59,0.15)]">
                   {icons[index]}
                 </div>
                 <div className="space-y-3">

--- a/components/sections/HowWeWork.tsx
+++ b/components/sections/HowWeWork.tsx
@@ -1,0 +1,42 @@
+import { ingeniumCopy } from "@/content/ingenium.copy";
+import Section from "@/components/ui/Section";
+
+const icons = ["🌼", "💛", "✨"];
+
+export default function HowWeWork() {
+  const { howWeWork } = ingeniumCopy;
+
+  return (
+    <Section id="como-trabajamos">
+      <div className="rounded-[2.5rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_12px_40px_rgba(184,138,59,0.1)] backdrop-blur sm:p-12">
+        <div className="space-y-10">
+          <div className="text-center">
+            <h2 className="text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {howWeWork.title}
+            </h2>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-3">
+            {howWeWork.items.map((item, index) => (
+              <div
+                key={item.title}
+                className="flex h-full flex-col gap-4 rounded-3xl border border-[#eadfce] bg-white/90 p-6 text-left shadow-sm"
+              >
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#f4e6d4] text-xl">
+                  {icons[index]}
+                </div>
+                <div className="space-y-3">
+                  <h3 className="text-lg font-semibold text-[#4a3725]">
+                    {item.title}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                    {item.body}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type SectionProps = {
+  id?: string;
+  className?: string;
+  children: ReactNode;
+};
+
+export default function Section({ id, className, children }: SectionProps) {
+  return (
+    <section id={id} className={cn("px-6 py-14 sm:py-20", className)}>
+      <div className="mx-auto w-full max-w-6xl">{children}</div>
+    </section>
+  );
+}

--- a/content/ingenium.copy.ts
+++ b/content/ingenium.copy.ts
@@ -1,0 +1,66 @@
+export const ingeniumCopy = {
+  brand: {
+    name: "Ingenium",
+    tagline: "Un espacio para aprender a organizarse por dentro",
+    intro:
+      "Ingenium es un espacio educativo de acompañamiento integral, orientado a niños y adolescentes. Fortalece el aprendizaje desde una mirada multidisciplinaria, trabajando hábitos de estudio, organización personal, comprensión de procesos y bienestar emocional. Cada propuesta se adapta a las necesidades de cada estudiante, respetando sus tiempos, intereses y potencialidades.",
+  },
+  hero: {
+    title: "Un espacio para aprender a organizarse por dentro",
+    subtitle:
+      "Apoyo educativo desde una mirada multidisciplinaria para potenciar hábitos de estudio, gestión del tiempo y bienestar emocional.",
+    ctaPrimary: { label: "Consultar por WhatsApp", href: "#contacto" },
+    ctaSecondary: { label: "Coordinar una entrevista", href: "#contacto" },
+  },
+  howWeWork: {
+    title: "¿Cómo trabajamos?",
+    items: [
+      {
+        title: "Organización y hábitos",
+        body: "Acompañamos al estudiante en la construcción de rutinas de estudio, planificación del tiempo y organización de tareas, priorizando estrategias que favorezcan la autonomía.",
+      },
+      {
+        title: "Comprensión y procesos",
+        body: "Guiamos al alumno a comprender cómo aprende, aplicando diferentes estrategias para interpretar consignas, resolver problemas y afianzar contenidos escolares.",
+      },
+      {
+        title: "Acompañamiento emocional",
+        body: "Brindamos contención socioemocional para fortalecer la autoestima, reducir el estrés académico y mejorar la relación con el aprendizaje.",
+      },
+    ],
+  },
+  audience: {
+    title: "¿Para quién es Ingenium?",
+    items: [
+      {
+        title: "Primaria",
+        body: "Apoyo escolar con seguimiento personalizado, enfocado en afianzar contenidos y generar hábitos de estudio desde edades tempranas.",
+      },
+      {
+        title: "Secundaria",
+        body: "Acompañamiento académico orientado a la organización, comprensión de contenidos y preparación para evaluaciones.",
+      },
+      {
+        title: "Recuperar la motivación",
+        body: "Espacios pensados para estudiantes que han perdido el interés o la confianza en su proceso de aprendizaje.",
+      },
+      {
+        title: "Ayuda personalizada",
+        body: "Intervenciones ajustadas a cada necesidad particular, combinando apoyo académico y emocional.",
+      },
+    ],
+  },
+  conditions: {
+    title: "Condiciones y marco de trabajo",
+    bullets: [
+      "Modalidad: presencial u online, según acuerdo previo.",
+      "Asistencia: las inasistencias deben avisarse con anticipación. Las clases no avisadas con antelación no son recuperables.",
+      "Pagos: los honorarios se acuerdan previamente y el pago se realiza de forma mensual.",
+      "Comunicación: el seguimiento se realiza en diálogo con las familias, priorizando una comunicación clara y respetuosa.",
+      "Marco: promovemos un espacio basado en respeto, tolerancia y confianza mutua.",
+      "Alcance: el acompañamiento no reemplaza tratamientos médicos ni terapéuticos cuando sean necesarios.",
+    ],
+    disclaimer:
+      "La información presentada es orientativa. Las condiciones completas del acompañamiento se acuerdan de manera personalizada al momento de la inscripción.",
+  },
+} as const;


### PR DESCRIPTION
### Motivation
- Provide a clean, componentized Home page that matches the warm, cream + gold mockup and keeps the page structure tidy.
- Drive all copy from a single source to avoid hard-coded strings across components using a new `content/ingenium.copy.ts` file.
- Keep changes scoped to Home and avoid global layout modifications or new dependencies.

### Description
- Added `content/ingenium.copy.ts` exporting `ingeniumCopy` with the exact required copy for all sections and CTAs.
- Implemented modular sections under `components/sections/` (`Hero`, `HowWeWork`, `Audience`, `Conditions`, `ContactCTA`) and a shared wrapper `components/ui/Section.tsx` and updated `app/page.tsx` to compose them.
- Styled components with Tailwind using a soft cream background (`#F6F0EA`), gold accent (`#B88A3B`), rounded cards and responsive, mobile-first layouts and anchors (`#como-trabajamos`, `#para-quien`, `#condiciones`, `#contacto`).
- Buttons and placeholders are implemented as requested (hero image placeholder, CTA linking to `#contacto`) and no new libraries were added.

### Testing
- Ran the dev server with `npm run dev` and the app started and responded to `GET /` with a `200` status.
- Captured a full-page screenshot using Playwright to validate layout rendering (artifact created: `ingenium-home.png`).
- Noted warnings about downloading Google Fonts during dev (fallback fonts used) but the page rendered correctly.
- No automated test failures were observed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c6177454832d92a7a9bdd480bb15)