### PR TITLE
Add paper-style backgrounds and floral decor accents

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -123,3 +123,51 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .bg-paper {
+    background-color: #f6efe7;
+    background-image: radial-gradient(
+        circle at top,
+        rgba(255, 255, 255, 0.75),
+        rgba(246, 233, 217, 0.95)
+      ),
+      radial-gradient(
+        circle at 80% 20%,
+        rgba(255, 245, 230, 0.85),
+        rgba(246, 233, 217, 0.2)
+      );
+  }
+
+  .bg-paper-section {
+    background-color: #f7f1ea;
+    background-image: radial-gradient(
+        circle at 20% 20%,
+        rgba(255, 255, 255, 0.7),
+        rgba(247, 239, 229, 0.9)
+      ),
+      radial-gradient(
+        circle at 90% 80%,
+        rgba(250, 236, 220, 0.65),
+        rgba(247, 239, 229, 0.2)
+      );
+  }
+
+  .bg-grain {
+    background-image: repeating-linear-gradient(
+        0deg,
+        rgba(80, 60, 40, 0.05) 0px,
+        rgba(80, 60, 40, 0.05) 1px,
+        transparent 1px,
+        transparent 3px
+      ),
+      repeating-linear-gradient(
+        90deg,
+        rgba(80, 60, 40, 0.04) 0px,
+        rgba(80, 60, 40, 0.04) 1px,
+        transparent 1px,
+        transparent 4px
+      );
+    mix-blend-mode: multiply;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { FlowerDecor, PaperBackground } from "@/components/decor/SectionDecor";
 import Audience from "@/components/sections/Audience";
 import Conditions from "@/components/sections/Conditions";
 import ContactCTA from "@/components/sections/ContactCTA";
@@ -6,11 +7,20 @@ import HowWeWork from "@/components/sections/HowWeWork";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-[#F6F0EA] bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.7),_rgba(246,240,234,1))] text-[#3f2f20]">
+    <div className="min-h-screen bg-paper text-[#3f2f20]">
       <main>
-        <Hero />
-        <HowWeWork />
-        <Audience />
+        <PaperBackground variant="hero">
+          <FlowerDecor position="hero-left" />
+          <Hero />
+        </PaperBackground>
+        <PaperBackground variant="section">
+          <FlowerDecor position="section-left" />
+          <HowWeWork />
+        </PaperBackground>
+        <PaperBackground variant="section">
+          <FlowerDecor position="section-right" />
+          <Audience />
+        </PaperBackground>
         <Conditions />
         <ContactCTA />
       </main>

--- a/components/decor/SectionDecor.tsx
+++ b/components/decor/SectionDecor.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+const decorMap = {
+  "hero-left": {
+    src: "/decor/flowers-left.svg",
+    className:
+      "bottom-0 left-0 w-[140px] sm:w-[180px] md:w-[220px] opacity-90",
+  },
+  "section-left": {
+    src: "/decor/flowers-small.svg",
+    className:
+      "top-6 left-0 w-[120px] sm:w-[160px] md:w-[190px] opacity-60",
+  },
+  "section-right": {
+    src: "/decor/flowers-sprinkles.svg",
+    className:
+      "bottom-6 right-0 w-[140px] sm:w-[180px] md:w-[220px] opacity-60",
+  },
+} as const;
+
+type PaperBackgroundProps = {
+  variant: "hero" | "section";
+  className?: string;
+  children: ReactNode;
+};
+
+type FlowerDecorProps = {
+  position: keyof typeof decorMap;
+};
+
+export function PaperBackground({
+  variant,
+  className,
+  children,
+}: PaperBackgroundProps) {
+  const backgroundClass =
+    variant === "hero" ? "bg-paper" : "bg-paper-section";
+
+  return (
+    <section
+      className={cn(
+        "relative overflow-hidden",
+        backgroundClass,
+        className,
+      )}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-grain opacity-40"
+      />
+      <div className="relative z-10">{children}</div>
+    </section>
+  );
+}
+
+export function FlowerDecor({ position }: FlowerDecorProps) {
+  const decor = decorMap[position];
+
+  return (
+    <Image
+      src={decor.src}
+      alt=""
+      aria-hidden
+      width={240}
+      height={220}
+      className={cn(
+        "pointer-events-none absolute select-none blur-[0.2px]",
+        "z-0",
+        decor.className,
+      )}
+    />
+  );
+}

--- a/public/decor/flowers-left.svg
+++ b/public/decor/flowers-left.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 220" fill="none">
+  <g stroke="#2f2418" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+    <path d="M32 210c30-42 54-76 92-110 30-27 60-48 98-70" />
+    <path d="M18 172c32-30 54-48 82-68" />
+    <path d="M72 200c18-30 44-62 80-92" />
+  </g>
+  <g fill="#f3c552" stroke="#2f2418" stroke-width="3">
+    <circle cx="152" cy="78" r="18" />
+    <circle cx="130" cy="92" r="12" />
+    <circle cx="170" cy="98" r="12" />
+    <circle cx="110" cy="140" r="14" />
+    <circle cx="92" cy="154" r="10" />
+    <circle cx="128" cy="158" r="10" />
+  </g>
+  <g fill="#2f2418">
+    <circle cx="118" cy="106" r="2" />
+    <circle cx="166" cy="120" r="2" />
+    <circle cx="138" cy="170" r="2" />
+  </g>
+</svg>

--- a/public/decor/flowers-small.svg
+++ b/public/decor/flowers-small.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 170" fill="none">
+  <g stroke="#2f2418" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+    <path d="M22 150c20-34 44-62 86-96" />
+    <path d="M60 154c18-30 34-52 60-74" />
+  </g>
+  <g fill="#f3c552" stroke="#2f2418" stroke-width="3">
+    <circle cx="112" cy="58" r="14" />
+    <circle cx="92" cy="72" r="10" />
+    <circle cx="130" cy="76" r="10" />
+    <circle cx="74" cy="112" r="12" />
+    <circle cx="56" cy="126" r="9" />
+    <circle cx="92" cy="126" r="9" />
+  </g>
+  <g fill="#2f2418">
+    <circle cx="102" cy="86" r="2" />
+    <circle cx="76" cy="140" r="2" />
+  </g>
+</svg>

--- a/public/decor/flowers-sprinkles.svg
+++ b/public/decor/flowers-sprinkles.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 160" fill="none">
+  <g fill="#2f2418" opacity="0.55">
+    <circle cx="24" cy="28" r="2" />
+    <circle cx="46" cy="44" r="1.6" />
+    <circle cx="70" cy="26" r="2.2" />
+    <circle cx="98" cy="52" r="1.8" />
+    <circle cx="130" cy="30" r="2" />
+    <circle cx="160" cy="48" r="1.6" />
+    <circle cx="192" cy="28" r="2.1" />
+    <circle cx="36" cy="82" r="1.6" />
+    <circle cx="64" cy="96" r="2.2" />
+    <circle cx="92" cy="82" r="1.8" />
+    <circle cx="120" cy="98" r="2" />
+    <circle cx="148" cy="84" r="1.6" />
+    <circle cx="176" cy="98" r="2.1" />
+    <circle cx="54" cy="130" r="2" />
+    <circle cx="86" cy="138" r="1.6" />
+    <circle cx="114" cy="126" r="2.2" />
+    <circle cx="146" cy="138" r="1.8" />
+    <circle cx="186" cy="128" r="2.2" />
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Reproduce the warm paper/acuarela background and add floral doodle ornaments to match the Ingenium mockup.  
- Provide reusable background and decoration primitives so styles can be applied without changing page structure.  
- Keep decorations non-interactive and accessible by ensuring `aria-hidden` and `pointer-events-none`.  

### Description
- Added three SVG assets under `public/decor/` (`flowers-left.svg`, `flowers-small.svg`, `flowers-sprinkles.svg`) for scalable doodle decorations.  
- Created `components/decor/SectionDecor.tsx` which exports `PaperBackground` and `FlowerDecor` components that handle background variants, grain overlay, absolute positioning, opacity and responsive sizing.  
- Introduced CSS utilities in `app/globals.css` (`bg-paper`, `bg-paper-section`, `bg-grain`) for the paper watercolor look and subtle grain overlay.  
- Applied `PaperBackground` and `FlowerDecor` in `app/page.tsx` to wrap the Hero and the “¿Cómo trabajamos?” / “¿Para quién es Ingenium?” sections, and changed the root container to use `bg-paper`.  

### Testing
- Ran `npm run dev` and the app started and served the home page (GET / 200) but emitted Google Fonts download warnings due to network access.  
- Captured an automated screenshot with a Playwright script which completed and produced `artifacts/ingenium-home.png`.  
- No runtime build errors were produced during the local dev run; warnings only related to external font fetching.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ce422488832d8743e83378455bb1)