### PR TITLE
Add paper backgrounds and floral decor elements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -123,3 +123,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .bg-paper {
+    background-color: #f7efe6;
+    background-image:
+      radial-gradient(circle at top, rgba(255, 255, 255, 0.7), rgba(247, 239, 230, 0.95)),
+      linear-gradient(120deg, rgba(255, 248, 238, 0.6), rgba(243, 230, 214, 0.9));
+  }
+
+  .bg-paper-section {
+    background-color: #f5ebdf;
+    background-image:
+      radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.65), rgba(245, 235, 223, 0.95)),
+      linear-gradient(160deg, rgba(255, 243, 230, 0.55), rgba(240, 225, 206, 0.92));
+  }
+
+  .bg-grain {
+    background-image:
+      repeating-linear-gradient(
+        0deg,
+        rgba(92, 74, 52, 0.05) 0px,
+        rgba(92, 74, 52, 0.05) 1px,
+        transparent 1px,
+        transparent 3px
+      ),
+      repeating-linear-gradient(
+        90deg,
+        rgba(92, 74, 52, 0.04) 0px,
+        rgba(92, 74, 52, 0.04) 1px,
+        transparent 1px,
+        transparent 3px
+      );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,14 +3,30 @@ import Conditions from "@/components/sections/Conditions";
 import ContactCTA from "@/components/sections/ContactCTA";
 import Hero from "@/components/sections/Hero";
 import HowWeWork from "@/components/sections/HowWeWork";
+import { FlowerDecor, PaperBackground } from "@/components/decor/SectionDecor";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-[#F6F0EA] bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.7),_rgba(246,240,234,1))] text-[#3f2f20]">
+    <div className="min-h-screen bg-paper text-[#3f2f20]">
       <main>
-        <Hero />
-        <HowWeWork />
-        <Audience />
+        <PaperBackground variant="hero">
+          <FlowerDecor position="hero-left" />
+          <div className="relative z-10">
+            <Hero />
+          </div>
+        </PaperBackground>
+        <PaperBackground variant="section">
+          <FlowerDecor position="section-left" />
+          <div className="relative z-10">
+            <HowWeWork />
+          </div>
+        </PaperBackground>
+        <PaperBackground variant="section">
+          <FlowerDecor position="section-right" />
+          <div className="relative z-10">
+            <Audience />
+          </div>
+        </PaperBackground>
         <Conditions />
         <ContactCTA />
       </main>

--- a/components/decor/SectionDecor.tsx
+++ b/components/decor/SectionDecor.tsx
@@ -1,0 +1,76 @@
+import Image from "next/image";
+import type React from "react";
+
+import { cn } from "@/lib/utils";
+
+type PaperBackgroundProps = React.HTMLAttributes<HTMLDivElement> & {
+  variant?: "hero" | "section";
+};
+
+export function PaperBackground({
+  variant = "section",
+  className,
+  children,
+  ...props
+}: PaperBackgroundProps) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden",
+        variant === "hero" ? "bg-paper" : "bg-paper-section",
+        className
+      )}
+      {...props}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 bg-grain opacity-40"
+      />
+      {children}
+    </div>
+  );
+}
+
+type FlowerDecorProps = {
+  position: "hero-left" | "section-left" | "section-right";
+};
+
+const decorStyles: Record<FlowerDecorProps["position"], { src: string; className: string; opacity: string }> = {
+  "hero-left": {
+    src: "/decor/flowers-left.svg",
+    className:
+      "absolute bottom-0 left-0 w-[140px] -translate-x-4 translate-y-6 sm:w-[180px] md:w-[220px]",
+    opacity: "opacity-90",
+  },
+  "section-left": {
+    src: "/decor/flowers-small.svg",
+    className:
+      "absolute left-0 top-8 w-[120px] -translate-x-3 sm:w-[160px] md:w-[190px]",
+    opacity: "opacity-60",
+  },
+  "section-right": {
+    src: "/decor/flowers-sprinkles.svg",
+    className:
+      "absolute bottom-8 right-0 w-[130px] translate-x-4 sm:w-[180px] md:w-[210px]",
+    opacity: "opacity-60",
+  },
+};
+
+export function FlowerDecor({ position }: FlowerDecorProps) {
+  const decor = decorStyles[position];
+
+  return (
+    <Image
+      src={decor.src}
+      alt=""
+      aria-hidden="true"
+      width={240}
+      height={200}
+      className={cn(
+        "pointer-events-none z-0 select-none blur-[0.2px]",
+        decor.className,
+        decor.opacity
+      )}
+    />
+  );
+}

--- a/public/decor/flowers-left.svg
+++ b/public/decor/flowers-left.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 200" fill="none">
+  <path d="M28 176c20-34 42-56 76-74 34-18 68-24 110-26" stroke="#2b2118" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M52 150c10-20 26-36 44-48" stroke="#2b2118" stroke-width="1.6" stroke-linecap="round" />
+  <path d="M108 124c6-10 14-20 28-30" stroke="#2b2118" stroke-width="1.6" stroke-linecap="round" />
+  <g>
+    <circle cx="92" cy="88" r="14" fill="#f2c94c" stroke="#2b2118" stroke-width="2" />
+    <circle cx="92" cy="88" r="4" fill="#f7e4a7" stroke="#2b2118" stroke-width="1.2" />
+    <path d="M78 88h28M92 74v28" stroke="#2b2118" stroke-width="1.2" stroke-linecap="round" />
+  </g>
+  <g>
+    <circle cx="156" cy="70" r="12" fill="#f6d167" stroke="#2b2118" stroke-width="2" />
+    <circle cx="156" cy="70" r="3" fill="#f7e4a7" stroke="#2b2118" stroke-width="1.1" />
+    <path d="M144 70h24M156 58v24" stroke="#2b2118" stroke-width="1.1" stroke-linecap="round" />
+  </g>
+  <g fill="#2b2118">
+    <circle cx="40" cy="166" r="2" />
+    <circle cx="64" cy="164" r="1.6" />
+    <circle cx="78" cy="150" r="1.6" />
+    <circle cx="120" cy="112" r="1.8" />
+    <circle cx="170" cy="92" r="1.5" />
+  </g>
+</svg>

--- a/public/decor/flowers-small.svg
+++ b/public/decor/flowers-small.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 140" fill="none">
+  <path d="M20 118c18-18 40-34 70-44 20-6 36-8 54-10" stroke="#2b2118" stroke-width="1.8" stroke-linecap="round" />
+  <g>
+    <circle cx="74" cy="58" r="10" fill="#f2c94c" stroke="#2b2118" stroke-width="1.8" />
+    <circle cx="74" cy="58" r="3" fill="#f7e4a7" stroke="#2b2118" stroke-width="1" />
+    <path d="M64 58h20M74 48v20" stroke="#2b2118" stroke-width="1" stroke-linecap="round" />
+  </g>
+  <g>
+    <circle cx="118" cy="44" r="8" fill="#f6d167" stroke="#2b2118" stroke-width="1.6" />
+    <circle cx="118" cy="44" r="2.5" fill="#f7e4a7" stroke="#2b2118" stroke-width="0.9" />
+    <path d="M110 44h16M118 36v16" stroke="#2b2118" stroke-width="0.9" stroke-linecap="round" />
+  </g>
+  <g fill="#2b2118">
+    <circle cx="32" cy="108" r="1.4" />
+    <circle cx="52" cy="96" r="1.3" />
+    <circle cx="92" cy="82" r="1.2" />
+    <circle cx="132" cy="58" r="1.2" />
+  </g>
+</svg>

--- a/public/decor/flowers-sprinkles.svg
+++ b/public/decor/flowers-sprinkles.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 160" fill="none">
+  <g fill="#f2c94c" stroke="#2b2118" stroke-width="1.2">
+    <circle cx="24" cy="32" r="6" />
+    <circle cx="86" cy="24" r="4.5" />
+    <circle cx="142" cy="42" r="5.5" />
+    <circle cx="172" cy="92" r="4" />
+    <circle cx="44" cy="116" r="5" />
+    <circle cx="104" cy="128" r="4.5" />
+    <circle cx="150" cy="130" r="3.8" />
+  </g>
+  <g stroke="#2b2118" stroke-linecap="round" stroke-width="1.4">
+    <path d="M64 64l6 4" />
+    <path d="M120 68l5-6" />
+    <path d="M60 92l-6-4" />
+    <path d="M130 110l6 2" />
+  </g>
+  <g fill="#2b2118">
+    <circle cx="20" cy="70" r="1.6" />
+    <circle cx="34" cy="90" r="1.4" />
+    <circle cx="74" cy="110" r="1.3" />
+    <circle cx="112" cy="52" r="1.4" />
+    <circle cx="188" cy="40" r="1.3" />
+    <circle cx="160" cy="64" r="1.2" />
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation

- Reproduce the warm paper/watercolor look of the Ingenium mock and add subtle floral doodle ornaments to key sections without changing page structure.
- Provide reusable background and decoration primitives so the look can be applied consistently across the app.

### Description

- Added lightweight paper and grain utilities in `app/globals.css` as `.bg-paper`, `.bg-paper-section` and `.bg-grain` to create the warm, textured backgrounds.
- Added three SVG assets under `public/decor/` (`flowers-left.svg`, `flowers-sprinkles.svg`, `flowers-small.svg`) that scale via `viewBox` and have transparent backgrounds.
- Added `components/decor/SectionDecor.tsx` exporting `PaperBackground` and `FlowerDecor` which render a paper wrapper and positioned decorative SVGs via `next/image` with `aria-hidden` and `pointer-events-none` and proper z-indexing.
- Wrapped the Hero, “¿Cómo trabajamos?” and “¿Para quién es Ingenium?” in `app/page.tsx` with `PaperBackground` and placed `FlowerDecor` instances behind content using `relative z-10` for content and `z-0` for decorations.

### Testing

- Ran `npm run dev -- --hostname 0.0.0.0 --port 3000` which started Next.js and served the site successfully (GET `/` returned `200`) with font download warnings due to network restrictions. 
- Captured a full-page screenshot of the home using Playwright to visually verify decorations were placed and responsive sizes applied. 
- The dev server compiled and rendered pages despite warnings about Google Fonts and a cross-origin dev warning. 
- All changes were committed (`Add paper backgrounds and floral decor`) and the new assets and component files are included in the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ce422488832d8743e83378455bb1)