### PR TITLE
Refine Ingenium visual styling and media config

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,8 +6,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-ingenium-sans);
   --font-mono: var(--font-geist-mono);
+  --font-serif: var(--font-ingenium-serif);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -47,7 +48,7 @@
 }
 
 :root {
-  --radius: 0.625rem;
+  --radius: 1rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.147 0.004 49.25);
   --card: oklch(1 0 0);
@@ -79,6 +80,17 @@
   --sidebar-accent-foreground: oklch(0.216 0.006 56.043);
   --sidebar-border: oklch(0.923 0.003 48.717);
   --sidebar-ring: oklch(0.709 0.01 56.259);
+  --ingenium-paper: #f6efe7;
+  --ingenium-paper-soft: #f8f1e9;
+  --ingenium-ink: #3f2f20;
+  --ingenium-ink-soft: #6a5743;
+  --ingenium-gold: #b88a3b;
+  --ingenium-gold-dark: #a6772f;
+  --ingenium-border: #eadfce;
+  --ingenium-shadow: 0 24px 60px rgba(166, 120, 50, 0.18);
+  --ingenium-shadow-soft: 0 16px 45px rgba(166, 120, 50, 0.14);
+  --ingenium-radius: 2.5rem;
+  --ingenium-radius-lg: 2.75rem;
 }
 
 .dark {
@@ -120,13 +132,31 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
+  }
+}
+
+@layer components {
+  .card-surface {
+    @apply rounded-[var(--ingenium-radius-lg)] border border-[var(--ingenium-border)] bg-white/80 shadow-[var(--ingenium-shadow)] backdrop-blur;
+  }
+
+  .panel-surface {
+    @apply rounded-[var(--ingenium-radius)] border border-[var(--ingenium-border)] bg-white/90 shadow-[var(--ingenium-shadow-soft)];
+  }
+
+  .btn-primary {
+    @apply inline-flex items-center justify-center rounded-full bg-[var(--ingenium-gold)] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[rgba(184,138,59,0.28)] transition hover:-translate-y-0.5 hover:bg-[var(--ingenium-gold-dark)] active:translate-y-0;
+  }
+
+  .btn-outline {
+    @apply inline-flex items-center justify-center rounded-full border border-[#d9c3a1] bg-white/80 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] active:translate-y-0;
   }
 }
 
 @layer utilities {
   .bg-paper {
-    background-color: #f6efe7;
+    background-color: var(--ingenium-paper);
     background-image: radial-gradient(
         circle at top,
         rgba(255, 255, 255, 0.75),
@@ -136,11 +166,12 @@
         circle at 80% 20%,
         rgba(255, 245, 230, 0.85),
         rgba(246, 233, 217, 0.2)
-      );
+      ),
+      linear-gradient(120deg, rgba(255, 234, 206, 0.35), transparent 55%);
   }
 
   .bg-paper-section {
-    background-color: #f7f1ea;
+    background-color: var(--ingenium-paper-soft);
     background-image: radial-gradient(
         circle at 20% 20%,
         rgba(255, 255, 255, 0.7),
@@ -150,7 +181,8 @@
         circle at 90% 80%,
         rgba(250, 236, 220, 0.65),
         rgba(247, 239, 229, 0.2)
-      );
+      ),
+      linear-gradient(160deg, rgba(255, 230, 198, 0.32), transparent 60%);
   }
 
   .bg-grain {
@@ -169,5 +201,18 @@
         transparent 4px
       );
     mix-blend-mode: multiply;
+  }
+
+  .hero-image-overlay {
+    background-image: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.35),
+        rgba(246, 231, 210, 0.7)
+      ),
+      radial-gradient(
+        circle at 20% 20%,
+        rgba(255, 255, 255, 0.45),
+        transparent 60%
+      );
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,19 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist_Mono, Manrope, Playfair_Display } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const ingeniumSans = Manrope({
+  variable: "--font-ingenium-sans",
   subsets: ["latin"],
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const ingeniumSerif = Playfair_Display({
+  variable: "--font-ingenium-serif",
   subsets: ["latin"],
 });
 
@@ -25,7 +30,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${ingeniumSans.variable} ${ingeniumSerif.variable} ${geistMono.variable} antialiased`}
       >
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import HowWeWork from "@/components/sections/HowWeWork";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-paper text-[#3f2f20]">
+    <div className="min-h-screen bg-paper text-[var(--ingenium-ink)]">
       <main>
         <PaperBackground variant="hero">
           <FlowerDecor position="hero-left" />
@@ -21,8 +21,14 @@ export default function Home() {
           <FlowerDecor position="section-right" />
           <Audience />
         </PaperBackground>
-        <Conditions />
-        <ContactCTA />
+        <PaperBackground variant="section">
+          <FlowerDecor position="section-left" />
+          <Conditions />
+        </PaperBackground>
+        <PaperBackground variant="section">
+          <FlowerDecor position="section-top-right" />
+          <ContactCTA />
+        </PaperBackground>
       </main>
     </div>
   );

--- a/components/decor/SectionDecor.tsx
+++ b/components/decor/SectionDecor.tsx
@@ -6,19 +6,24 @@ import { cn } from "@/lib/utils";
 
 const decorMap = {
   "hero-left": {
-    src: "/decor/flowers-left.svg",
+    src: "/decor/flower-spray-left.svg",
     className:
-      "bottom-0 left-0 w-[140px] sm:w-[180px] md:w-[220px] opacity-90",
+      "bottom-0 left-0 w-[150px] sm:w-[190px] md:w-[230px] opacity-90",
   },
   "section-left": {
-    src: "/decor/flowers-small.svg",
+    src: "/decor/flower-spray-top.svg",
     className:
-      "top-6 left-0 w-[120px] sm:w-[160px] md:w-[190px] opacity-60",
+      "top-6 left-[-10px] w-[140px] sm:w-[170px] md:w-[200px] opacity-70",
   },
   "section-right": {
-    src: "/decor/flowers-sprinkles.svg",
+    src: "/decor/flower-spray-right.svg",
     className:
-      "bottom-6 right-0 w-[140px] sm:w-[180px] md:w-[220px] opacity-60",
+      "bottom-6 right-[-10px] w-[150px] sm:w-[190px] md:w-[230px] opacity-70",
+  },
+  "section-top-right": {
+    src: "/decor/flower-spray-right.svg",
+    className:
+      "top-4 right-[-20px] w-[120px] sm:w-[160px] md:w-[190px] opacity-60 rotate-[-12deg]",
   },
 } as const;
 

--- a/components/sections/Audience.tsx
+++ b/components/sections/Audience.tsx
@@ -1,30 +1,48 @@
+import Image from "next/image";
+
 import { ingeniumCopy } from "@/content/ingenium.copy";
+import { ingeniumImages } from "@/data/images";
 import Section from "@/components/ui/Section";
 
 export default function Audience() {
   const { audience } = ingeniumCopy;
+  const audienceImages = [
+    ingeniumImages.cardPrimary,
+    ingeniumImages.cardSecondary,
+    ingeniumImages.cardAdults,
+    ingeniumImages.cardTeams,
+  ];
 
   return (
     <Section id="para-quien">
-      <div className="rounded-[2.75rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_18px_50px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
+      <div className="card-surface p-8 sm:p-12">
         <div className="space-y-10">
           <div className="text-center">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[var(--ingenium-ink)] sm:text-3xl">
               {audience.title}
             </h2>
           </div>
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-            {audience.items.map((item) => (
+            {audience.items.map((item, index) => (
               <div
                 key={item.title}
-                className="flex h-full flex-col gap-4 rounded-3xl border border-[#eadfce] bg-white/90 p-5 shadow-[0_10px_30px_rgba(157,121,68,0.12)]"
+                className="panel-surface flex h-full flex-col gap-4 p-5"
               >
-                <div className="h-32 w-full rounded-2xl bg-gradient-to-br from-[#f2ddbf] via-[#f7ead6] to-white shadow-inner" />
+                <div className="relative h-32 w-full overflow-hidden rounded-2xl border border-[#f1e1cb] bg-gradient-to-br from-[#f2ddbf] via-[#f7ead6] to-white shadow-inner">
+                  <Image
+                    src={audienceImages[index]}
+                    alt={item.title}
+                    fill
+                    className="object-cover"
+                    sizes="(min-width: 1024px) 220px, (min-width: 768px) 40vw, 80vw"
+                  />
+                  <div className="pointer-events-none absolute inset-0 hero-image-overlay opacity-70" />
+                </div>
                 <div className="space-y-2">
                   <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
                     {item.title}
                   </h3>
-                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                  <p className="text-sm leading-relaxed text-[var(--ingenium-ink-soft)]">
                     {item.body}
                   </p>
                 </div>

--- a/components/sections/Conditions.tsx
+++ b/components/sections/Conditions.tsx
@@ -6,15 +6,15 @@ export default function Conditions() {
 
   return (
     <Section id="condiciones">
-      <div className="rounded-[2.75rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_18px_50px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
+      <div className="card-surface p-8 sm:p-12">
         <div className="space-y-6">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[var(--ingenium-ink)] sm:text-3xl">
             {conditions.title}
           </h2>
-          <ul className="space-y-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
+          <ul className="space-y-3 text-sm leading-relaxed text-[var(--ingenium-ink-soft)] sm:text-base">
             {conditions.bullets.map((bullet) => (
               <li key={bullet} className="flex gap-3">
-                <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                <span className="mt-2 h-2 w-2 rounded-full bg-[var(--ingenium-gold)]" />
                 <span>{bullet}</span>
               </li>
             ))}

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -6,31 +6,31 @@ export default function ContactCTA() {
 
   return (
     <Section id="contacto" className="pb-20">
-      <div className="rounded-[2.75rem] border border-[#eadfce] bg-gradient-to-br from-white/95 via-white/85 to-[#f7efe4] p-8 shadow-[0_18px_50px_rgba(184,138,59,0.14)] backdrop-blur sm:p-12">
+      <div className="card-surface bg-gradient-to-br from-white/95 via-white/85 to-[#f7efe4] p-8 sm:p-12">
         <div className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
           <div className="space-y-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[#B88A3B]">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--ingenium-gold)]">
               {brand.name}
             </p>
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[var(--ingenium-ink)] sm:text-3xl">
               {brand.tagline}
             </h2>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            <p className="text-sm leading-relaxed text-[var(--ingenium-ink-soft)] sm:text-base">
               Coordinemos una entrevista para conocer la situación de cada
               estudiante y proponer un plan de acompañamiento a medida.
             </p>
           </div>
-          <div className="space-y-4 rounded-3xl border border-[#eadfce] bg-white/85 p-6 text-left shadow-[0_10px_30px_rgba(157,121,68,0.12)]">
+          <div className="panel-surface space-y-4 p-6 text-left">
             <p className="text-sm font-semibold text-[#4a3725]">
               Contacto
             </p>
-            <p className="text-sm leading-relaxed text-[#6a5743]">
+            <p className="text-sm leading-relaxed text-[var(--ingenium-ink-soft)]">
               Dejanos tu consulta y nos pondremos en contacto para coordinar
               disponibilidad, modalidad y objetivos de acompañamiento.
             </p>
             <a
               href={hero.ctaPrimary.href}
-              className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/20 transition hover:translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+              className="btn-primary w-full sm:w-auto sm:text-base"
             >
               {hero.ctaPrimary.label}
             </a>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,4 +1,7 @@
+import Image from "next/image";
+
 import { ingeniumCopy } from "@/content/ingenium.copy";
+import { ingeniumImages } from "@/data/images";
 import Section from "@/components/ui/Section";
 
 export default function Hero() {
@@ -6,41 +9,50 @@ export default function Hero() {
 
   return (
     <Section className="pt-16 sm:pt-20">
-      <div className="rounded-[2.75rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_20px_60px_rgba(184,138,59,0.16)] backdrop-blur sm:p-12">
+      <div className="card-surface p-8 sm:p-12">
         <div className="grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
           <div className="space-y-6">
             <div className="space-y-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[#B88A3B]">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--ingenium-gold)]">
                 {brand.name}
               </p>
-              <h1 className="font-serif text-3xl font-semibold tracking-tight text-[#3f2f20] sm:text-4xl lg:text-5xl">
+              <h1 className="font-serif text-3xl font-semibold tracking-tight text-[var(--ingenium-ink)] sm:text-4xl lg:text-5xl">
                 {hero.title}
               </h1>
-              <p className="text-base leading-relaxed text-[#5c4a36] sm:text-lg">
+              <p className="text-base leading-relaxed text-[var(--ingenium-ink-soft)] sm:text-lg">
                 {hero.subtitle}
               </p>
             </div>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            <p className="text-sm leading-relaxed text-[var(--ingenium-ink-soft)] sm:text-base">
               {brand.intro}
             </p>
             <div className="flex flex-col gap-3 sm:flex-row">
               <a
                 href={hero.ctaPrimary.href}
-                className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/25 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+                className="btn-primary w-full sm:w-auto sm:text-base"
               >
                 {hero.ctaPrimary.label}
               </a>
               <a
                 href={hero.ctaSecondary.href}
-                className="inline-flex w-full items-center justify-center rounded-full border border-[#d9c3a1] bg-white/80 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] sm:w-auto sm:text-base"
+                className="btn-outline w-full sm:w-auto sm:text-base"
               >
                 {hero.ctaSecondary.label}
               </a>
             </div>
           </div>
           <div className="relative">
-            <div className="flex aspect-[4/3] items-center justify-center rounded-[2.5rem] border border-[#eadfce] bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.9),_rgba(246,230,210,0.9)),linear-gradient(135deg,_rgba(255,255,255,0.6),_rgba(244,224,198,0.85))] text-sm font-semibold uppercase tracking-[0.2em] text-[#b58a44] shadow-inner">
-              Imagen
+            <div className="relative aspect-[4/3] overflow-hidden rounded-[2.5rem] border border-[var(--ingenium-border)] bg-white shadow-[0_18px_40px_rgba(140,96,39,0.18)]">
+              <Image
+                src={ingeniumImages.heroFamily}
+                alt="Familia estudiando en casa"
+                fill
+                className="object-cover"
+                sizes="(min-width: 1024px) 520px, 90vw"
+                priority
+              />
+              <div className="pointer-events-none absolute inset-0 hero-image-overlay" />
+              <div className="pointer-events-none absolute inset-0 bg-grain opacity-30" />
             </div>
           </div>
         </div>

--- a/components/sections/HowWeWork.tsx
+++ b/components/sections/HowWeWork.tsx
@@ -8,10 +8,10 @@ export default function HowWeWork() {
 
   return (
     <Section id="como-trabajamos">
-      <div className="rounded-[2.75rem] border border-[#eadfce] bg-white/80 p-8 shadow-[0_18px_50px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12">
+      <div className="card-surface p-8 sm:p-12">
         <div className="space-y-10">
           <div className="text-center">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[var(--ingenium-ink)] sm:text-3xl">
               {howWeWork.title}
             </h2>
           </div>
@@ -19,16 +19,16 @@ export default function HowWeWork() {
             {howWeWork.items.map((item, index) => (
               <div
                 key={item.title}
-                className="flex h-full flex-col gap-4 rounded-3xl border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_10px_30px_rgba(157,121,68,0.12)]"
+                className="panel-surface flex h-full flex-col gap-4 p-6 text-left"
               >
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#f4e6d4] text-xl">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#f4e6d4] text-xl shadow-[0_10px_25px_rgba(184,138,59,0.18)]">
                   {icons[index]}
                 </div>
                 <div className="space-y-3">
                   <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
                     {item.title}
                   </h3>
-                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                  <p className="text-sm leading-relaxed text-[var(--ingenium-ink-soft)]">
                     {item.body}
                   </p>
                 </div>

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -10,7 +10,7 @@ type SectionProps = {
 
 export default function Section({ id, className, children }: SectionProps) {
   return (
-    <section id={id} className={cn("px-6 py-14 sm:py-20", className)}>
+    <section id={id} className={cn("px-6 py-16 sm:py-24", className)}>
       <div className="mx-auto w-full max-w-6xl">{children}</div>
     </section>
   );

--- a/data/images.ts
+++ b/data/images.ts
@@ -1,0 +1,8 @@
+// Para cambiar fotos, reemplazar archivos en /public/media/ingenium/people/ o editar data/images.ts.
+export const ingeniumImages = {
+  heroFamily: "/media/ingenium/people/hero-family.svg",
+  cardPrimary: "/media/ingenium/people/primaria.svg",
+  cardSecondary: "/media/ingenium/people/secundaria.svg",
+  cardAdults: "/media/ingenium/people/adultos.svg",
+  cardTeams: "/media/ingenium/people/equipos.svg",
+} as const;

--- a/public/decor/flower-spray-left.svg
+++ b/public/decor/flower-spray-left.svg
@@ -1,0 +1,17 @@
+<svg width="260" height="260" viewBox="0 0 260 260" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#1E1B16" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M40 210C80 170 120 150 160 140"/>
+    <path d="M50 170C70 150 90 130 110 110"/>
+    <path d="M70 220C90 200 120 190 150 180"/>
+  </g>
+  <g fill="#F6C84C" stroke="#1E1B16" stroke-width="6">
+    <circle cx="170" cy="120" r="22"/>
+    <circle cx="120" cy="90" r="18"/>
+    <circle cx="200" cy="160" r="16"/>
+  </g>
+  <g fill="#1E1B16">
+    <circle cx="80" cy="80" r="6"/>
+    <circle cx="210" cy="90" r="5"/>
+    <circle cx="130" cy="200" r="5"/>
+  </g>
+</svg>

--- a/public/decor/flower-spray-right.svg
+++ b/public/decor/flower-spray-right.svg
@@ -1,0 +1,17 @@
+<svg width="260" height="260" viewBox="0 0 260 260" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#1E1B16" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M220 50C180 90 150 130 130 170"/>
+    <path d="M200 90C180 110 160 140 150 170"/>
+    <path d="M210 130C190 160 170 190 150 210"/>
+  </g>
+  <g fill="#F6C84C" stroke="#1E1B16" stroke-width="6">
+    <circle cx="120" cy="170" r="22"/>
+    <circle cx="150" cy="120" r="18"/>
+    <circle cx="90" cy="130" r="16"/>
+  </g>
+  <g fill="#1E1B16">
+    <circle cx="70" cy="200" r="5"/>
+    <circle cx="190" cy="210" r="6"/>
+    <circle cx="110" cy="80" r="5"/>
+  </g>
+</svg>

--- a/public/decor/flower-spray-top.svg
+++ b/public/decor/flower-spray-top.svg
@@ -1,0 +1,17 @@
+<svg width="280" height="200" viewBox="0 0 280 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#1E1B16" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M40 60C90 80 130 100 170 130"/>
+    <path d="M90 40C120 60 150 90 180 120"/>
+    <path d="M140 30C160 60 190 90 230 110"/>
+  </g>
+  <g fill="#F6C84C" stroke="#1E1B16" stroke-width="6">
+    <circle cx="70" cy="90" r="18"/>
+    <circle cx="120" cy="120" r="20"/>
+    <circle cx="200" cy="90" r="16"/>
+  </g>
+  <g fill="#1E1B16">
+    <circle cx="50" cy="30" r="5"/>
+    <circle cx="220" cy="40" r="5"/>
+    <circle cx="180" cy="150" r="6"/>
+  </g>
+</svg>

--- a/public/media/ingenium/people/adultos.svg
+++ b/public/media/ingenium/people/adultos.svg
@@ -1,0 +1,9 @@
+<svg width="720" height="520" viewBox="0 0 720 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="520" rx="60" fill="#F6EFE7"/>
+  <rect x="55" y="55" width="610" height="410" rx="50" fill="#F2DEC4"/>
+  <circle cx="260" cy="220" r="68" fill="#F6C84C" stroke="#1E1B16" stroke-width="9"/>
+  <circle cx="470" cy="210" r="58" fill="#F8D56B" stroke="#1E1B16" stroke-width="9"/>
+  <path d="M190 380C250 320 350 300 400 300C450 300 540 320 600 380" stroke="#1E1B16" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="140" cy="120" r="9" fill="#1E1B16"/>
+  <circle cx="590" cy="410" r="10" fill="#1E1B16"/>
+</svg>

--- a/public/media/ingenium/people/equipos.svg
+++ b/public/media/ingenium/people/equipos.svg
@@ -1,0 +1,10 @@
+<svg width="720" height="520" viewBox="0 0 720 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="520" rx="60" fill="#F6EFE7"/>
+  <rect x="50" y="50" width="620" height="420" rx="50" fill="#F3E1C9"/>
+  <circle cx="200" cy="210" r="58" fill="#F6C84C" stroke="#1E1B16" stroke-width="9"/>
+  <circle cx="360" cy="190" r="52" fill="#F8D56B" stroke="#1E1B16" stroke-width="9"/>
+  <circle cx="510" cy="220" r="58" fill="#F6C84C" stroke="#1E1B16" stroke-width="9"/>
+  <path d="M140 380C220 320 310 300 360 300C420 300 520 320 590 380" stroke="#1E1B16" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="110" cy="420" r="9" fill="#1E1B16"/>
+  <circle cx="620" cy="120" r="9" fill="#1E1B16"/>
+</svg>

--- a/public/media/ingenium/people/hero-family.svg
+++ b/public/media/ingenium/people/hero-family.svg
@@ -1,0 +1,21 @@
+<svg width="1200" height="900" viewBox="0 0 1200 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="900" rx="80" fill="#F6EFE7"/>
+  <rect x="60" y="70" width="1080" height="760" rx="70" fill="#F4E6D4"/>
+  <g opacity="0.9">
+    <circle cx="400" cy="350" r="90" fill="#F6C84C" stroke="#1E1B16" stroke-width="10"/>
+    <circle cx="750" cy="320" r="78" fill="#F6C84C" stroke="#1E1B16" stroke-width="10"/>
+    <circle cx="570" cy="270" r="60" fill="#F8D56B" stroke="#1E1B16" stroke-width="10"/>
+  </g>
+  <g stroke="#1E1B16" stroke-width="12" stroke-linecap="round">
+    <path d="M300 720C340 610 470 560 560 560C650 560 780 610 820 720"/>
+    <path d="M440 700C460 620 520 590 570 590C620 590 690 620 710 700"/>
+  </g>
+  <g>
+    <circle cx="220" cy="180" r="12" fill="#1E1B16"/>
+    <circle cx="980" cy="650" r="10" fill="#1E1B16"/>
+    <circle cx="910" cy="210" r="8" fill="#1E1B16"/>
+    <circle cx="310" cy="610" r="9" fill="#1E1B16"/>
+  </g>
+  <path d="M110 560C190 470 270 450 330 470" stroke="#B88A3B" stroke-width="12" stroke-linecap="round"/>
+  <path d="M870 520C940 470 1020 470 1080 520" stroke="#B88A3B" stroke-width="12" stroke-linecap="round"/>
+</svg>

--- a/public/media/ingenium/people/primaria.svg
+++ b/public/media/ingenium/people/primaria.svg
@@ -1,0 +1,9 @@
+<svg width="720" height="520" viewBox="0 0 720 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="520" rx="60" fill="#F6EFE7"/>
+  <rect x="40" y="40" width="640" height="440" rx="50" fill="#F7E9D6"/>
+  <circle cx="220" cy="220" r="70" fill="#F6C84C" stroke="#1E1B16" stroke-width="9"/>
+  <circle cx="460" cy="200" r="60" fill="#F8D56B" stroke="#1E1B16" stroke-width="9"/>
+  <path d="M170 380C220 310 320 300 360 300C400 300 500 310 550 380" stroke="#1E1B16" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="110" cy="100" r="8" fill="#1E1B16"/>
+  <circle cx="610" cy="420" r="10" fill="#1E1B16"/>
+</svg>

--- a/public/media/ingenium/people/secundaria.svg
+++ b/public/media/ingenium/people/secundaria.svg
@@ -1,0 +1,9 @@
+<svg width="720" height="520" viewBox="0 0 720 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="520" rx="60" fill="#F6EFE7"/>
+  <rect x="50" y="50" width="620" height="420" rx="50" fill="#F5E3CB"/>
+  <circle cx="260" cy="210" r="64" fill="#F6C84C" stroke="#1E1B16" stroke-width="9"/>
+  <circle cx="480" cy="230" r="64" fill="#F8D56B" stroke="#1E1B16" stroke-width="9"/>
+  <path d="M190 380C260 320 360 300 410 300C460 300 560 320 620 380" stroke="#1E1B16" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="120" cy="430" r="9" fill="#1E1B16"/>
+  <circle cx="600" cy="120" r="8" fill="#1E1B16"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Bring the site visually closer to the provided mock with an editorial/paper look and decorative floral accents without redesigning content. 
- Make people/photos easy to replace by centralizing media paths into a single configuration file. 
- Provide consistent design tokens, radii, shadows and base components so styles are predictable across sections. 
- Ensure decorative elements are non-interactive and do not break responsiveness.

### Description
- Added `data/images.ts` exporting `ingeniumImages` and created placeholder SVGs under `public/media/ingenium/people/` so components reference media via constants instead of hardcoded paths. 
- Created floral spray SVGs in `public/decor/` and switched `components/decor/SectionDecor.tsx` to the new assets and updated positions/sizes. 
- Introduced design tokens and component utilities in `app/globals.css` (variables like `--ingenium-paper`, `--ingenium-gold`, `.card-surface`, `.btn-primary`, `.btn-outline`, `.hero-image-overlay`) and adjusted global radii/spacing. 
- Wired new fonts via `next/font` in `app/layout.tsx` and updated sections (`Hero`, `Audience`, `HowWeWork`, `Conditions`, `ContactCTA`, `Section`) to use tokens, the new image constants, image overlays, updated spacing and the pill button styles.

### Testing
- Started the dev server and requested the home page successfully (`GET / 200`) so the app renders. 
- Captured visual smoke screenshots for desktop and mobile at `artifacts/ingenium-home-desktop.png` and `artifacts/ingenium-home-mobile.png`. 
- Noted Google Fonts download warnings due to network restrictions and confirmed fallback system fonts were used while pages still rendered. 
- No automated test failures were reported during the visual smoke run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695542771270832d81c4258c3aef8cac)