### PR TITLE
Add Google Maps link to Contact card

### DIFF
--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -28,6 +28,20 @@ export default function ContactCTA() {
               Dejanos tu consulta y nos pondremos en contacto para coordinar
               disponibilidad, modalidad y objetivos de acompañamiento.
             </p>
+            <div className="space-y-1 text-sm text-[#6a5743]">
+              <p>
+                📍 Suyai 2632, Barrio Cordón del Plata, Vistalba, Luján de Cuyo
+              </p>
+              <a
+                href="https://www.google.com/maps/search/?api=1&query=Suyai%202632%20Barrio%20Cord%C3%B3n%20del%20Plata%2C%20Vistalba%2C%20Luj%C3%A1n%20de%20Cuyo%2C%20Mendoza%2C%20Argentina"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Abrir ubicación de Ingenium en Google Maps"
+                className="text-sm font-semibold text-[#B88A3B] hover:text-[#a97c33]"
+              >
+                Ver en Google Maps
+              </a>
+            </div>
             <a
               href={hero.ctaPrimary.href}
               className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/20 transition hover:translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"


### PR DESCRIPTION
### Motivation
- Insert a discreet address/link to Google Maps inside the existing “Contacto” card on the home page so users can open the physical location without changing the layout. 
- Keep the current visual design and reuse existing typography/color conventions to avoid altering spacing or component structure. 
- Provide a direct link that opens in a new tab and includes accessible labeling and safe `rel` attributes. 

### Description
- Added an address block containing the line `📍 Suyai 2632, Barrio Cordón del Plata, Vistalba, Luján de Cuyo` and a `Ver en Google Maps` link to `components/sections/ContactCTA.tsx`. 
- The link uses `target="_blank"`, `rel="noopener noreferrer"` and `aria-label="Abrir ubicación de Ingenium en Google Maps"`. 
- Styling reuses existing small/text color classes (`text-sm`, `text-[#6a5743]`, `text-[#B88A3B]`) and avoids introducing new layout containers or images. 

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` which rendered the home page successfully but showed Google Fonts download warnings and fell back to local fonts. 
- Ran a Playwright script to load the home page and capture a screenshot of the Contact section, confirming the address and link are visible, and the script completed successfully. 
- Observed a successful `GET / 200` render of the home page during the dev run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955acbf8cdc832daaace0ceaab242f8)