### PR TITLE
Refine homepage copy and add modality preface

### DIFF
--- a/components/sections/Conditions.tsx
+++ b/components/sections/Conditions.tsx
@@ -11,6 +11,9 @@ export default function Conditions() {
           <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
             {conditions.title}
           </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {conditions.preface}
+          </p>
           <ul className="space-y-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
             {conditions.bullets.map((bullet) => (
               <li key={bullet} className="flex gap-3">

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -39,7 +39,7 @@ export default function ContactCTA() {
                 aria-label="Abrir ubicación de Ingenium en Google Maps"
                 className="text-sm font-semibold text-[#B88A3B] hover:text-[#a97c33]"
               >
-                Ver en Google Maps
+                Ver ubicación en Google Maps
               </a>
             </div>
             <a

--- a/content/ingenium.copy.ts
+++ b/content/ingenium.copy.ts
@@ -5,12 +5,12 @@ export const ingeniumCopy = {
     name: "Ingenium",
     tagline: "Un espacio para aprender a organizarse por dentro",
     intro:
-      "Ingenium es un espacio educativo de acompañamiento integral, orientado a niños y adolescentes. Fortalece el aprendizaje desde una mirada multidisciplinaria, trabajando hábitos de estudio, organización personal, comprensión de procesos y bienestar emocional. Cada propuesta se adapta a las necesidades de cada estudiante, respetando sus tiempos, intereses y potencialidades.",
+      "Ingenium es un espacio educativo de acompañamiento integral, orientado a niños y adolescentes. Trabajamos de forma personalizada, respetando los tiempos, intereses y potencialidades de cada estudiante, fortaleciendo la autonomía, la organización personal y la relación con el aprendizaje.",
   },
   hero: {
     title: "Un espacio para aprender a organizarse por dentro",
     subtitle:
-      "Apoyo educativo desde una mirada multidisciplinaria para potenciar hábitos de estudio, gestión del tiempo y bienestar emocional.",
+      "Apoyo educativo para niños y adolescentes, desde una mirada multidisciplinaria que fortalece hábitos de estudio, comprensión de procesos y bienestar emocional.",
     ctaPrimary: {
       label: "Consultar por WhatsApp",
       href: ingeniumContact.whatsappUrl,
@@ -22,15 +22,15 @@ export const ingeniumCopy = {
     items: [
       {
         title: "Organización y hábitos",
-        body: "Acompañamos al estudiante en la construcción de rutinas de estudio, planificación del tiempo y organización de tareas, priorizando estrategias que favorezcan la autonomía.",
+        body: "Acompañamos la construcción de rutinas de estudio, planificación del tiempo y organización de tareas, con estrategias simples que favorecen la autonomía.",
       },
       {
         title: "Comprensión y procesos",
-        body: "Guiamos al alumno a comprender cómo aprende, aplicando diferentes estrategias para interpretar consignas, resolver problemas y afianzar contenidos escolares.",
+        body: "Guiamos al estudiante a comprender cómo aprende, con recursos para interpretar consignas, resolver problemas y afianzar contenidos escolares.",
       },
       {
         title: "Acompañamiento emocional",
-        body: "Brindamos contención socioemocional para fortalecer la autoestima, reducir el estrés académico y mejorar la relación con el aprendizaje.",
+        body: "Ofrecemos un entorno de confianza que fortalece la autoestima, reduce el estrés académico y mejora la relación con el aprendizaje.",
       },
     ],
   },
@@ -39,26 +39,27 @@ export const ingeniumCopy = {
     items: [
       {
         title: "Primaria",
-        body: "Apoyo escolar con seguimiento personalizado, enfocado en afianzar contenidos y generar hábitos de estudio desde edades tempranas.",
+        body: "Apoyo escolar con seguimiento personalizado para afianzar contenidos y construir hábitos de estudio desde edades tempranas.",
       },
       {
         title: "Secundaria",
-        body: "Acompañamiento académico orientado a la organización, comprensión de contenidos y preparación para evaluaciones.",
+        body: "Acompañamiento académico centrado en la organización, la comprensión de contenidos y la preparación para evaluaciones.",
       },
       {
         title: "Recuperar la motivación",
-        body: "Espacios pensados para estudiantes que han perdido el interés o la confianza en su proceso de aprendizaje.",
+        body: "Espacios para estudiantes que atraviesan desmotivación, inseguridad o dificultad para sostener el estudio, sin que eso defina sus capacidades.",
       },
       {
         title: "Ayuda personalizada",
-        body: "Intervenciones ajustadas a cada necesidad particular, combinando apoyo académico y emocional.",
+        body: "Acompañamientos ajustados a cada necesidad, combinando lo académico con lo emocional.",
       },
     ],
   },
   conditions: {
     title: "Condiciones y marco de trabajo",
+    preface:
+      "El acompañamiento puede realizarse de forma presencial u online, según acuerdo previo. Las condiciones, frecuencia y modalidad se conversan de manera personalizada con cada familia, priorizando un encuadre claro y respetuoso.",
     bullets: [
-      "Modalidad: presencial u online, según acuerdo previo.",
       "Asistencia: las inasistencias deben avisarse con anticipación. Las clases no avisadas con antelación no son recuperables.",
       "Pagos: los honorarios se acuerdan previamente y el pago se realiza de forma mensual.",
       "Comunicación: el seguimiento se realiza en diálogo con las familias, priorizando una comunicación clara y respetuosa.",


### PR DESCRIPTION
### Motivation
- Make the homepage clearer for families while preserving the site's warm, non‑institutional tone. 
- Provide a more explicit definition of Ingenium and clearer pedagogical framing without changing layout or visual design. 
- Clarify modality/encuadre information near the contact area so families know options before reaching out. 
- Small UX tweak to the contact block label for clearer wording.

### Description
- Updated copy in `content/ingenium.copy.ts` including the brand `intro`, hero `subtitle`, `howWeWork` item bodies, and `audience` item bodies to improve clarity and normalise learning challenges. 
- Added a `conditions.preface` entry in `content/ingenium.copy.ts` to state that accompaniment can be `presencial u online` and that modality/frequency are agreed personally. 
- Rendered the new preface by adding a paragraph to `components/sections/Conditions.tsx` and removed the now-redundant standalone modality bullet. 
- Renamed the map link label in `components/sections/ContactCTA.tsx` to `Ver ubicación en Google Maps` for clearer CTA text.

### Testing
- Started the dev server with `npm run dev` and confirmed the app served the homepage (GET / returned 200). 
- Ran a Playwright script that opened `http://127.0.0.1:3000` and captured a full-page screenshot to verify visual layout and text placement. 
- Observed Google Fonts download warnings from Next.js but the page rendered successfully with fallback fonts. 
- No unit or integration test suites were run since this is a content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b4fcb3cc832dae606a2220996463)