### PR TITLE
Actualizar título de la sección de audiencia en Ingenium

### DIFF
--- a/content/ingenium.copy.ts
+++ b/content/ingenium.copy.ts
@@ -35,7 +35,7 @@ export const ingeniumCopy = {
     ],
   },
   audience: {
-    title: "¿Para quién es Ingenium?",
+    title: "¿En qué momentos acompaña Ingenium?",
     items: [
       {
         title: "Primaria",


### PR DESCRIPTION
### Motivation
- La sección estaba titulada `"¿Para quién es Ingenium?"` pero los cuatro bloques describen situaciones y procesos, no grupos etarios.
- El objetivo es que el título dialogue semánticamente con los items y refleje momentos de acompañamiento sin nombrar públicos por edad.

### Description
- Se reemplazó el título en `content/ingenium.copy.ts` de `"¿Para quién es Ingenium?"` a `"¿En qué momentos acompaña Ingenium?"`.
- No se modificó el contenido de los cuatro boxes, ni se tocaron ilustraciones, tipografías, tamaños, colores, espaciados, grilla o layout responsive.

### Testing
- No se ejecutaron pruebas automatizadas porque es un cambio exclusivo de contenido. 
- Se verificó localmente que el archivo `content/ingenium.copy.ts` contiene el nuevo título sin otros cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955f5c46078832da82484a7e1d49d65)