### PR TITLE
Use PNG illustrations for FloralDecor and FloralIcon (add `icon` prop)

### DIFF
--- a/components/FloralDecor.tsx
+++ b/components/FloralDecor.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import Image from "next/image";
 
 import { cn } from "@/lib/utils";
 
@@ -25,77 +26,23 @@ type FloralDecorProps = {
 };
 
 type FloralIconProps = {
+  icon?: "flor" | "flores" | "corazon" | "floresCorazon";
   className?: string;
 };
 
-function FloralSvg({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 240 240"
-      aria-hidden="true"
-      className={className}
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M120 215C118 178 120 142 122 110"
-        stroke="#4a3725"
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <path
-        d="M122 118C104 102 93 86 84 66"
-        stroke="#4a3725"
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <path
-        d="M125 128C144 112 160 92 170 70"
-        stroke="#4a3725"
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <circle
-        cx="84"
-        cy="60"
-        r="20"
-        fill="#f7d86c"
-        stroke="#4a3725"
-        strokeWidth="4"
-      />
-      <circle
-        cx="170"
-        cy="64"
-        r="18"
-        fill="#f7d86c"
-        stroke="#4a3725"
-        strokeWidth="4"
-      />
-      <circle cx="84" cy="60" r="4" fill="#4a3725" />
-      <circle cx="170" cy="64" r="4" fill="#4a3725" />
-      <circle cx="96" cy="50" r="2.5" fill="#4a3725" />
-      <circle cx="72" cy="70" r="2.5" fill="#4a3725" />
-      <circle cx="160" cy="54" r="2.5" fill="#4a3725" />
-      <circle cx="182" cy="74" r="2.5" fill="#4a3725" />
-      <path
-        d="M110 164C96 150 80 142 66 130"
-        stroke="#4a3725"
-        strokeWidth="3"
-        strokeLinecap="round"
-      />
-      <path
-        d="M132 166C148 152 164 146 178 134"
-        stroke="#4a3725"
-        strokeWidth="3"
-        strokeLinecap="round"
-      />
-      <circle cx="66" cy="130" r="8" fill="#f7d86c" stroke="#4a3725" strokeWidth="3" />
-      <circle cx="178" cy="134" r="8" fill="#f7d86c" stroke="#4a3725" strokeWidth="3" />
-      <circle cx="66" cy="130" r="2" fill="#4a3725" />
-      <circle cx="178" cy="134" r="2" fill="#4a3725" />
-    </svg>
-  );
-}
+const decorImages = {
+  leftTop: "/media/ingenium/illustrations/flor-sola.png",
+  leftMid: "/media/ingenium/illustrations/flores-dos.png",
+  rightTop: "/media/ingenium/illustrations/corazon.png",
+  rightBottom: "/media/ingenium/illustrations/flores-corazon.png",
+} as const;
+
+const iconImages = {
+  flor: "/media/ingenium/illustrations/flor-sola.png",
+  flores: "/media/ingenium/illustrations/flores-dos.png",
+  corazon: "/media/ingenium/illustrations/corazon.png",
+  floresCorazon: "/media/ingenium/illustrations/flores-corazon.png",
+} as const;
 
 export function PaperBackground({
   variant,
@@ -132,12 +79,20 @@ export function FloralDecor({ variant, className }: FloralDecorProps) {
         className,
       )}
     >
-      <FloralSvg className="h-full w-full" />
+      <Image
+        src={decorImages[variant]}
+        alt=""
+        aria-hidden="true"
+        width={240}
+        height={240}
+        className="h-full w-full object-contain"
+      />
+      {/* Tip: pass "mix-blend-multiply" or "mix-blend-soft-light" via className to enable blending. */}
     </div>
   );
 }
 
-export function FloralIcon({ className }: FloralIconProps) {
+export function FloralIcon({ icon = "flor", className }: FloralIconProps) {
   return (
     <div
       aria-hidden="true"
@@ -146,7 +101,14 @@ export function FloralIcon({ className }: FloralIconProps) {
         className,
       )}
     >
-      <FloralSvg className="h-8 w-8" />
+      <Image
+        src={iconImages[icon]}
+        alt=""
+        aria-hidden="true"
+        width={32}
+        height={32}
+        className="h-8 w-8 object-contain"
+      />
     </div>
   );
 }

--- a/components/sections/HowWeWork.tsx
+++ b/components/sections/HowWeWork.tsx
@@ -4,6 +4,7 @@ import { FloralIcon } from "@/components/FloralDecor";
 
 export default function HowWeWork() {
   const { howWeWork } = ingeniumCopy;
+  const iconByIndex = ["flor", "flores", "corazon"] as const;
 
   return (
     <Section id="como-trabajamos">
@@ -20,7 +21,10 @@ export default function HowWeWork() {
                 key={item.title}
                 className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
               >
-                <FloralIcon className={index === 1 ? "bg-[#f5e2c7]" : undefined} />
+                <FloralIcon
+                  icon={iconByIndex[index]}
+                  className={index === 1 ? "bg-[#f5e2c7]" : undefined}
+                />
                 <div className="space-y-3">
                   <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
                     {item.title}


### PR DESCRIPTION
### Motivation
- Replace the inline floral SVG artwork with the provided PNG illustrations while keeping the existing positioning/opacity responsive system. 
- Preserve the `PaperBackground` API and visual behavior (bg-paper/bg-paper-section and bg-grain) unchanged. 
- Allow small card icons to use the same illustrations while keeping the circular container and original sizing. 
- Provide an easy way to enable blend modes via class names without changing defaults.

### Description
- Replaced the internal `FloralSvg` with Next.js `Image` and added `decorImages` mapping for variants in `components/FloralDecor.tsx`. 
- Added an `icon?: "flor" | "flores" | "corazon" | "floresCorazon"` prop to `FloralIcon` and `iconImages` mapping, and kept the circular container and sizes (`h-12 w-12` container and `h-8 w-8` icon). 
- Updated `components/sections/HowWeWork.tsx` to pass card-specific icons (`iconByIndex = ["flor","flores","corazon"]`) so each card shows the intended illustration. 
- Kept `decorVariants`, classes, `pointer-events-none`, `blur-[0.4px]`, and overall API (`FloralDecor` signature and `className`) intact, and added a comment about enabling `mix-blend-multiply`/`mix-blend-soft-light` via `className`.

### Testing
- Started the dev server with `npm run dev` and the app compiled and served the homepage (`GET /`) returning `200`. 
- Captured a full-page screenshot using Playwright (homepage rendered with the new images) which completed successfully. 
- Next.js logged warnings about failing to download Google Fonts but fell back to system fonts and did not block rendering. 
- No automated test failures were observed for the changes above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c2fa7bc0832d9e49700548ea8e97)