### PR TITLE
Replace floral SVGs with PNG illustrations

### DIFF
--- a/components/FloralDecor.tsx
+++ b/components/FloralDecor.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import Image from "next/image";
+
 import { cn } from "@/lib/utils";
 
 const decorVariants = {
@@ -26,76 +28,22 @@ type FloralDecorProps = {
 
 type FloralIconProps = {
   className?: string;
+  icon?: "flor" | "flores" | "corazon" | "floresCorazon";
 };
 
-function FloralSvg({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 240 240"
-      aria-hidden="true"
-      className={className}
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M120 215C118 178 120 142 122 110"
-        stroke="#4a3725"
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <path
-        d="M122 118C104 102 93 86 84 66"
-        stroke="#4a3725"
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <path
-        d="M125 128C144 112 160 92 170 70"
-        stroke="#4a3725"
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <circle
-        cx="84"
-        cy="60"
-        r="20"
-        fill="#f7d86c"
-        stroke="#4a3725"
-        strokeWidth="4"
-      />
-      <circle
-        cx="170"
-        cy="64"
-        r="18"
-        fill="#f7d86c"
-        stroke="#4a3725"
-        strokeWidth="4"
-      />
-      <circle cx="84" cy="60" r="4" fill="#4a3725" />
-      <circle cx="170" cy="64" r="4" fill="#4a3725" />
-      <circle cx="96" cy="50" r="2.5" fill="#4a3725" />
-      <circle cx="72" cy="70" r="2.5" fill="#4a3725" />
-      <circle cx="160" cy="54" r="2.5" fill="#4a3725" />
-      <circle cx="182" cy="74" r="2.5" fill="#4a3725" />
-      <path
-        d="M110 164C96 150 80 142 66 130"
-        stroke="#4a3725"
-        strokeWidth="3"
-        strokeLinecap="round"
-      />
-      <path
-        d="M132 166C148 152 164 146 178 134"
-        stroke="#4a3725"
-        strokeWidth="3"
-        strokeLinecap="round"
-      />
-      <circle cx="66" cy="130" r="8" fill="#f7d86c" stroke="#4a3725" strokeWidth="3" />
-      <circle cx="178" cy="134" r="8" fill="#f7d86c" stroke="#4a3725" strokeWidth="3" />
-      <circle cx="66" cy="130" r="2" fill="#4a3725" />
-      <circle cx="178" cy="134" r="2" fill="#4a3725" />
-    </svg>
-  );
-}
+const decorImages: Record<keyof typeof decorVariants, string> = {
+  leftTop: "/media/ingenium/illustrations/flor-sola.png",
+  leftMid: "/media/ingenium/illustrations/flores-dos.png",
+  rightTop: "/media/ingenium/illustrations/corazon.png",
+  rightBottom: "/media/ingenium/illustrations/flores-corazon.png",
+};
+
+const floralIconImages = {
+  flor: "/media/ingenium/illustrations/flor-sola.png",
+  flores: "/media/ingenium/illustrations/flores-dos.png",
+  corazon: "/media/ingenium/illustrations/corazon.png",
+  floresCorazon: "/media/ingenium/illustrations/flores-corazon.png",
+};
 
 export function PaperBackground({
   variant,
@@ -132,12 +80,21 @@ export function FloralDecor({ variant, className }: FloralDecorProps) {
         className,
       )}
     >
-      <FloralSvg className="h-full w-full" />
+      <div className="relative h-full w-full">
+        <Image
+          src={decorImages[variant]}
+          alt=""
+          fill
+          sizes="(min-width: 768px) 270px, (min-width: 640px) 220px, 170px"
+          className="h-full w-full object-contain"
+        />
+      </div>
+      {/* Add a mix-blend class like "mix-blend-multiply" via className when needed. */}
     </div>
   );
 }
 
-export function FloralIcon({ className }: FloralIconProps) {
+export function FloralIcon({ className, icon = "flor" }: FloralIconProps) {
   return (
     <div
       aria-hidden="true"
@@ -146,7 +103,13 @@ export function FloralIcon({ className }: FloralIconProps) {
         className,
       )}
     >
-      <FloralSvg className="h-8 w-8" />
+      <Image
+        src={floralIconImages[icon]}
+        alt=""
+        width={32}
+        height={32}
+        className="h-8 w-8 object-contain"
+      />
     </div>
   );
 }

--- a/components/sections/HowWeWork.tsx
+++ b/components/sections/HowWeWork.tsx
@@ -4,6 +4,7 @@ import { FloralIcon } from "@/components/FloralDecor";
 
 export default function HowWeWork() {
   const { howWeWork } = ingeniumCopy;
+  const iconByIndex = ["flor", "flores", "corazon"] as const;
 
   return (
     <Section id="como-trabajamos">
@@ -20,7 +21,10 @@ export default function HowWeWork() {
                 key={item.title}
                 className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
               >
-                <FloralIcon className={index === 1 ? "bg-[#f5e2c7]" : undefined} />
+                <FloralIcon
+                  icon={iconByIndex[index] ?? "flor"}
+                  className={index === 1 ? "bg-[#f5e2c7]" : undefined}
+                />
                 <div className="space-y-3">
                   <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
                     {item.title}


### PR DESCRIPTION
### Motivation
- Replace the inline floral SVG artwork with the provided PNG illustration assets while preserving the existing decorative layout and responsive sizing.
- Keep the `PaperBackground` API and visual behavior (bg-paper/bg-paper-section and bg-grain) unchanged so backgrounds continue to behave as before.
- Provide small card icons that match the page themes using the same illustration set for visual consistency.

### Description
- Replaced the inline `FloralSvg` with Next.js `Image` in `components/FloralDecor.tsx`, mapping `decorVariants` positions to `/media/ingenium/illustrations/*` PNG files and using `fill` + `object-contain` to avoid layout shifts.
- Added an optional `icon?: "flor" | "flores" | "corazon" | "floresCorazon"` prop to `FloralIcon` and swapped the SVG for a `32x32` `Image` with `className="h-8 w-8 object-contain"` to preserve the original icon sizing and circle container.
- Updated `components/sections/HowWeWork.tsx` to pass the appropriate icons per card (`flor`, `flores`, `corazon`) while not modifying any copy or headings.
- Preserved `decorVariants`, `className` usage, `pointer-events-none`, `blur-[0.4px]`, and added a comment showing how to enable `mix-blend` via `className` (no mix-blend enabled by default).

### Testing
- Started the dev server with `npm run dev` and confirmed the app responded with `GET / 200`, indicating the page rendered successfully.
- Captured a Playwright screenshot of the home page (`/`) which completed and produced `artifacts/ingenium-home.png` to visually validate the changes.
- Observed Google Fonts download warnings during the dev run due to network requests, but these did not prevent the page from rendering.
- No unit tests were added; no automated unit test failures were observed during the manual dev run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c2fa7bc0832d9e49700548ea8e97)