### PR TITLE
Ajustar superposición de decoraciones florales y escalar íconos

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,15 +9,15 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-paper text-[#3f2f20]">
       <main>
-        <PaperBackground variant="hero">
+        <PaperBackground variant="hero" allowOverflow>
           <FloralDecor variant="leftTop" />
           <Hero />
         </PaperBackground>
-        <PaperBackground variant="section">
+        <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="leftMid" />
           <HowWeWork />
         </PaperBackground>
-        <PaperBackground variant="section">
+        <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="rightBottom" />
           <Audience />
         </PaperBackground>

--- a/components/FloralDecor.tsx
+++ b/components/FloralDecor.tsx
@@ -5,18 +5,19 @@ import { cn } from "@/lib/utils";
 
 const decorVariants = {
   leftTop:
-    "left-0 top-4 w-[160px] sm:w-[210px] md:w-[260px] opacity-35",
+    "-left-6 top-4 w-[160px] opacity-35 sm:-left-10 sm:w-[210px] md:-left-14 md:w-[260px]",
   leftMid:
-    "left-0 top-1/2 w-[140px] -translate-y-1/2 sm:w-[190px] md:w-[230px] opacity-30",
+    "-left-6 top-1/2 w-[140px] -translate-y-1/2 opacity-30 sm:-left-10 sm:w-[190px] md:-left-14 md:w-[230px]",
   rightBottom:
-    "bottom-0 right-0 w-[170px] sm:w-[220px] md:w-[270px] opacity-30",
+    "-right-6 bottom-0 w-[170px] opacity-30 sm:-right-10 sm:w-[220px] md:-right-14 md:w-[270px]",
   rightTop:
-    "right-0 top-6 w-[150px] sm:w-[200px] md:w-[240px] opacity-35",
+    "-right-6 top-6 w-[150px] opacity-35 sm:-right-10 sm:w-[200px] md:-right-14 md:w-[240px]",
 } as const;
 
 type PaperBackgroundProps = {
   variant: "hero" | "section";
   className?: string;
+  allowOverflow?: boolean;
   children: ReactNode;
 };
 
@@ -47,6 +48,7 @@ const iconImages = {
 export function PaperBackground({
   variant,
   className,
+  allowOverflow = false,
   children,
 }: PaperBackgroundProps) {
   const backgroundClass =
@@ -55,14 +57,15 @@ export function PaperBackground({
   return (
     <section
       className={cn(
-        "relative overflow-hidden",
+        "relative",
+        allowOverflow ? "overflow-visible" : "overflow-hidden",
         backgroundClass,
         className,
       )}
     >
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 bg-grain opacity-45"
+        className="pointer-events-none absolute inset-0 z-0 bg-grain opacity-45"
       />
       <div className="relative z-10">{children}</div>
     </section>
@@ -74,7 +77,7 @@ export function FloralDecor({ variant, className }: FloralDecorProps) {
     <div
       aria-hidden="true"
       className={cn(
-        "pointer-events-none absolute z-0 select-none blur-[0.4px]",
+        "pointer-events-none absolute z-[1] select-none blur-[0.4px]",
         decorVariants[variant],
         className,
       )}
@@ -97,7 +100,7 @@ export function FloralIcon({ icon = "flor", className }: FloralIconProps) {
     <div
       aria-hidden="true"
       className={cn(
-        "flex h-12 w-12 items-center justify-center rounded-full bg-[#f8ecd7]",
+        "flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-[#f8ecd7]",
         className,
       )}
     >
@@ -105,9 +108,9 @@ export function FloralIcon({ icon = "flor", className }: FloralIconProps) {
         src={iconImages[icon]}
         alt=""
         aria-hidden="true"
-        width={32}
-        height={32}
-        className="h-8 w-8 object-contain"
+        width={40}
+        height={40}
+        className="h-10 w-10 scale-[1.35] object-contain"
       />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Evitar que los PNG florales queden ocultos por el card blanco central o por contenedores con `overflow:hidden` y hacer que asomen en pantallas pequeñas.
- Mejorar la legibilidad de los `FloralIcon` cuando las imágenes PNG contienen mucho espacio vacío alrededor.
- Mantener la API y el look de `PaperBackground` y la lógica responsive, permitiendo ajustes mínimos para permitir overflow cuando sea necesario.
- Preparar soporte opt-in para `mix-blend-mode` vía `className` sin activarlo por defecto.

### Description
- Añadida la prop opcional `allowOverflow?: boolean` a `PaperBackground` (default `false`) y aplicada `overflow-visible` cuando está activa para permitir que la decoración no sea recortada; la propiedad se usó en `app/page.tsx` en las secciones con decor.
- Ajustados los `decorVariants` para usar offsets negativos (`-left-6 sm:-left-10 md:-left-14`, etc.) y así permitir que los decor laterales asomen en mobile y breakpoints mayores.
- Cambiada la capa/z-index del decor (`z-[1]`) y del `bg-grain` (`z-0`) para que el decor quede entre el fondo granular y el contenido, y mantenida la pequeña `blur` existente.
- Mejorado `FloralIcon` añadiendo `overflow-hidden` al contenedor circular, aumentando el `Image` a `width/height=40`, usando `h-10 w-10 scale-[1.35] object-contain` para compensar espacio vacío en los PNG, y conservando el prop `icon` y la paleta de imágenes; el `mix-blend-mode` sigue siendo opt-in mediante `className`.

### Testing
- Levantado el servidor de desarrollo con `npm run dev` y la página principal respondió `GET / 200`, con advertencias de descarga de fuentes pero sin fallo de renderizado.
- Capturada una captura de pantalla full-page con un script de Playwright para verificar visualmente el posicionamiento de las decoraciones y el tamaño de los iconos; la imagen fue generada y guardada en `artifacts/ingenium-home.png`.
- No se ejecutaron tests unitarios automatizados adicionales en este cambio y no se detectaron errores de ejecución durante las pruebas automáticas realizadas.
- Resultado: las pruebas automáticas realizadas (dev server + screenshot) se completaron correctamente con advertencias de fuentes pero sin fallos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c8b417ec832dbd1141657fe2b31f)