### PR TITLE
Refine floral decor placement and remove duplicated right separator

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import { FloralDecor, PaperBackground } from "@/components/FloralDecor";
 import Audience from "@/components/sections/Audience";
 import Conditions from "@/components/sections/Conditions";
 import ContactCTA from "@/components/sections/ContactCTA";
+import FloralSeparator from "@/components/sections/FloralSeparator";
 import Hero from "@/components/sections/Hero";
 import HowWeWork from "@/components/sections/HowWeWork";
 
@@ -18,9 +19,9 @@ export default function Home() {
           <HowWeWork />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <FloralDecor variant="rightBottom" />
           <Audience />
         </PaperBackground>
+        <FloralSeparator />
         <Conditions />
         <ContactCTA />
       </main>

--- a/components/FloralDecor.tsx
+++ b/components/FloralDecor.tsx
@@ -7,7 +7,7 @@ const decorVariants = {
   leftTop:
     "-left-6 top-4 w-[160px] opacity-35 sm:-left-10 sm:w-[210px] md:-left-14 md:w-[260px]",
   leftMid:
-    "-left-6 top-1/2 w-[140px] -translate-y-1/2 opacity-30 sm:-left-10 sm:w-[190px] md:-left-14 md:w-[230px]",
+    "-left-10 top-2 w-[190px] opacity-35 sm:-left-14 sm:-top-2 sm:w-[240px] md:-left-20 md:-top-4 md:w-[280px]",
   rightBottom:
     "-right-6 bottom-0 w-[170px] opacity-30 sm:-right-10 sm:w-[220px] md:-right-14 md:w-[270px]",
   rightTop:

--- a/components/sections/FloralSeparator.tsx
+++ b/components/sections/FloralSeparator.tsx
@@ -1,0 +1,36 @@
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+type FloralSeparatorProps = {
+  wrapperClassName?: string;
+  className?: string;
+};
+
+export default function FloralSeparator({
+  wrapperClassName,
+  className,
+}: FloralSeparatorProps) {
+  return (
+    <div
+      className={cn(
+        "relative flex justify-center -mt-8 -mb-8 py-6 sm:-mt-12 sm:-mb-12 sm:py-8 lg:py-10",
+        wrapperClassName,
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className={cn("pointer-events-none select-none opacity-30", className)}
+      >
+        <Image
+          src="/media/ingenium/illustrations/flores-corazon.png"
+          alt=""
+          aria-hidden="true"
+          width={380}
+          height={380}
+          className="h-auto w-[260px] object-contain sm:w-[320px] md:w-[380px]"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Move the left-mid floral asset down so the two-flower image no longer exposes a contrasting background edge. 
- Remove the right-side floral decoration to avoid duplicating the centered `flores-corazon` separator. 
- Keep decorative elements non-interactive and visually layered between `PaperBackground` and content. 
- Preserve responsive sizing so the decor reads well on mobile and desktop.

### Description
- Adjusted `decorVariants.leftMid` in `components/FloralDecor.tsx` to lower and resize the left-mid floral placement and increase opacity. 
- Removed the right-side decor by deleting `<FloralDecor variant="rightBottom" />` from `app/page.tsx`. 
- Added and inserted a centered separator component `components/sections/FloralSeparator.tsx` and rendered it between `Audience` and `Conditions`. 
- Ensured the separator and decor use `pointer-events-none` and `aria-hidden` to remain non-interactive.

### Testing
- Started the dev server with `npm run dev` and the home route returned `GET / 200`, confirming the app rendered. 
- Generated visual verification screenshots with Playwright (`artifacts/floral-separator-desktop.png`, `artifacts/floral-separator-mobile.png`) successfully. 
- The server emitted Google Fonts download warnings but fallback fonts were used and pages still rendered. 
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d3409894832da620e3326b6f0fa2)