### PR TITLE
Normalize contact data, update Maps link and add JSON-LD

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ingeniumContact } from "@/lib/contact";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -22,11 +23,33 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "EducationalOrganization",
+    name: ingeniumContact.name,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: `${ingeniumContact.addressParts.streetAddress}, ${ingeniumContact.addressParts.neighborhood}, ${ingeniumContact.addressParts.department}`,
+      addressLocality: ingeniumContact.addressParts.addressLocality,
+      addressRegion: ingeniumContact.addressParts.addressRegion,
+      addressCountry: ingeniumContact.addressParts.addressCountry,
+    },
+    telephone: ingeniumContact.whatsappNumber.replace(/\s/g, ""),
+    hasMap: ingeniumContact.googleMapsUrl,
+  };
+
   return (
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(structuredData),
+          }}
+        />
         {children}
       </body>
     </html>

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -1,4 +1,5 @@
 import { ingeniumCopy } from "@/content/ingenium.copy";
+import { ingeniumContact } from "@/lib/contact";
 import Section from "@/components/ui/Section";
 
 export default function ContactCTA() {
@@ -30,10 +31,10 @@ export default function ContactCTA() {
             </p>
             <div className="space-y-1 text-sm text-[#6a5743]">
               <p>
-                📍 Suyai 2632, Barrio Cordón del Plata, Vistalba, Luján de Cuyo
+                📍 {ingeniumContact.addressLine}
               </p>
               <a
-                href="https://www.google.com/maps/search/?api=1&query=Suyai%202632%20Barrio%20Cord%C3%B3n%20del%20Plata%2C%20Vistalba%2C%20Luj%C3%A1n%20de%20Cuyo%2C%20Mendoza%2C%20Argentina"
+                href={ingeniumContact.googleMapsUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Abrir ubicación de Ingenium en Google Maps"

--- a/content/ingenium.contact.ts
+++ b/content/ingenium.contact.ts
@@ -1,3 +1,0 @@
-export const ingeniumContact = {
-  whatsappUrl: "https://wa.me/5492615010488",
-} as const;

--- a/content/ingenium.copy.ts
+++ b/content/ingenium.copy.ts
@@ -1,4 +1,4 @@
-import { ingeniumContact } from "@/content/ingenium.contact";
+import { ingeniumContact } from "@/lib/contact";
 
 export const ingeniumCopy = {
   brand: {

--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -1,0 +1,17 @@
+export const ingeniumContact = {
+  name: "INGENIUM Apoyo escolar",
+  whatsappNumber: "+54 9 2615010488",
+  whatsappUrl: "https://wa.me/5492615010488",
+  addressLine:
+    "Suyai 2632, Barrio Valle Cordón del Plata, Vistalba, Luján de Cuyo, Mendoza, Argentina",
+  addressParts: {
+    streetAddress: "Suyai 2632",
+    neighborhood: "Barrio Valle Cordón del Plata",
+    addressLocality: "Vistalba",
+    department: "Luján de Cuyo",
+    addressRegion: "Mendoza",
+    addressCountry: "Argentina",
+  },
+  googleMapsUrl:
+    "https://www.google.com/maps/place/INGENIUM+Apoyo+escolar/@-33.0267097,-68.8816128,13z/data=!4m6!3m5!1s0x967e0b5c69f0da01:0xaa5459df15828d10!8m2!3d-33.0148945!4d-68.8870224!16s%2Fg%2F11h2qtp_2b",
+} as const;


### PR DESCRIPTION
### Motivation

- Centralize and normalize Ingenium NAP (name, address, phone) and Maps link to avoid inconsistencies across the site.
- Ensure the visible address uses the canonical neighborhood `Barrio Valle Cordón del Plata` and remove legacy variants.
- Use a single source of truth for contact data so all CTAs (WhatsApp / Maps) reference the same canonical values.
- Improve SEO understanding of the organization by adding structured `JSON-LD` (schema.org) data.

### Description

- Added `lib/contact.ts` exporting `ingeniumContact` with canonical fields: `name`, `whatsappNumber`, `whatsappUrl`, `addressLine`, `addressParts`, and `googleMapsUrl`.
- Replaced hardcoded address and Maps URL in `components/sections/ContactCTA.tsx` with `ingeniumContact.addressLine` and `ingeniumContact.googleMapsUrl` while preserving layout and links (`target="_blank" rel="noopener noreferrer"`).
- Updated `content/ingenium.copy.ts` to import the canonical WhatsApp URL from `lib/contact.ts` and removed the old `content/ingenium.contact.ts` file.
- Injected `JSON-LD` for an `EducationalOrganization` in `app/layout.tsx` using the canonical address, telephone and `hasMap` link from `ingeniumContact`.

### Testing

- Ran repository-wide searches (`rg`) for the legacy Maps search URL and for `Cordón del Plata`, confirming replacements and that the canonical data now lives in `lib/contact.ts` (search checks succeeded).
- Ran repository-wide searches for `wa.me`/WhatsApp references confirming they point to `https://wa.me/5492615010488` (search checks succeeded).
- No unit tests or CI builds were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d8769ba4832db58746640ace9849)