### PR TITLE
Emphasize 'Apoyo escolar' in HERO and update '¿Qué brindamos?'

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -12,12 +12,12 @@ export default function Hero() {
         <div className="grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
           <div className="space-y-6">
             <div className="space-y-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[#B88A3B]">
+              <h1 className="text-3xl font-semibold uppercase tracking-[0.25em] text-[#B88A3B] sm:text-4xl lg:text-5xl">
                 {brand.name}
-              </p>
-              <h1 className="font-serif text-3xl font-semibold tracking-tight text-[#3f2f20] sm:text-4xl lg:text-5xl">
-                {hero.title}
               </h1>
+              <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl lg:text-4xl">
+                {hero.title}
+              </h2>
               <p className="text-base leading-relaxed text-[#5c4a36] sm:text-lg">
                 {hero.subtitle}
               </p>

--- a/content/ingenium.copy.ts
+++ b/content/ingenium.copy.ts
@@ -5,12 +5,12 @@ export const ingeniumCopy = {
     name: "Ingenium",
     tagline: "Acompañamiento para organizarse por dentro",
     intro:
-      "Espacio educativo de acompañamiento integral para distintas etapas de la vida. Trabajo personalizado que fortalece autonomía, organización y vínculo con el aprendizaje.",
+      "Organización, hábitos, comprensión y bienestar.",
   },
   hero: {
-    title: "Aprender a organizarse",
+    title: "Apoyo escolar",
     subtitle:
-      "Acompañamiento educativo en cada etapa. Hábitos, comprensión y bienestar.",
+      "Primaria, Secundaria y Universidad. Modalidad individual o grupal en grupos reducidos.",
     ctaPrimary: {
       label: "Consultar por WhatsApp",
       href: ingeniumContact.whatsappUrl,
@@ -18,19 +18,19 @@ export const ingeniumCopy = {
     ctaSecondary: { label: "Coordinar una entrevista", href: "#contacto" },
   },
   howWeWork: {
-    title: "¿Cómo trabajamos?",
+    title: "¿Qué brindamos?",
     items: [
       {
-        title: "Organización y hábitos",
-        body: "Rutinas de estudio y organización del tiempo con estrategias simples para ganar autonomía.",
+        title: "Apoyo escolar",
+        body: "Acompañamiento para primaria, secundaria y universidad. Modalidad individual o grupal en grupos reducidos.",
       },
       {
-        title: "Comprensión y procesos",
-        body: "Recursos para comprender consignas, resolver problemas y afianzar contenidos en evaluaciones.",
+        title: "Ingreso",
+        body: "Preparación para ingresos a colegios secundarios de la UNCuyo. Preparación para ingresos universitarios (principalmente UNCuyo).",
       },
       {
-        title: "Acompañamiento emocional",
-        body: "Entorno de confianza que reduce el estrés y mejora la relación con el aprendizaje.",
+        title: "Cursos",
+        body: "Cursos y capacitaciones a medida, diseñados según la necesidad de quien los solicita.",
       },
     ],
   },


### PR DESCRIPTION
### Motivation
- Make the HERO communicate immediately that the main service is `Apoyo escolar` while preserving existing visual design and components. 
- Raise the visual hierarchy of the brand name `Ingenium` so it reads clearly as the institute name on first glance. 
- Surface the modalities (levels and individual/group formats) in a short, mobile-friendly line under the service title. 
- Reorganize the offerings section to present the three lines of work as `Apoyo escolar`, `Ingreso`, and `Cursos` without structural or stylistic changes.

### Description
- Updated `content/ingenium.copy.ts` to set `hero.title` to `Apoyo escolar`, replace `hero.subtitle` with modality text, simplify `brand.intro`, and rename `howWeWork.title` to `¿Qué brindamos?` while replacing its items with `Apoyo escolar`, `Ingreso`, and `Cursos` and their short bodies. 
- Modified `components/sections/Hero.tsx` to render the brand as a larger uppercase `h1` and the service title as an `h2`, adjusting size classes to raise brand hierarchy while keeping colors, fonts, layout, CTAs, and imagery unchanged. 
- All changes are content and hierarchy-only, following the constraint to avoid modifying palettes, typography, illustrations, spacing, or adding/removing sections. 
- Committed the changes with the message `Reorder hero messaging and offerings`.

### Testing
- Started the dev server with `npm run dev`, which reported the local URL and started successfully. 
- Attempted a Playwright script to capture a screenshot to `artifacts/hero-update-v2.png`, but the Chromium process crashed and the screenshot run failed. 
- No other automated tests were run in this rollout. 
- The changes were committed locally after verification of file diffs and server startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957099a47e8832d9a9a2f565e8b0e60)