### PR TITLE
docs: document image accessibility decisions and list unused public assets

### DIFF
--- a/content/ingenium.media.ts
+++ b/content/ingenium.media.ts
@@ -9,3 +9,38 @@ export const ingeniumMedia = {
     personalized: "/media/ingenium/illustrations/audience-personalized-support.png",
   },
 } as const;
+
+/**
+ * Resumen de accesibilidad de imágenes en UI:
+ * - Significativas (alt descriptivo):
+ *   - /media/ingenium/illustrations/hero-learning-accompaniment_1.png → "Acompañamiento personalizado para estudiantes" (components/sections/Hero.tsx)
+ *   - /media/ingenium/illustrations/audience-*.png → alt={item.title} (components/sections/Audience.tsx)
+ * - Decorativas (alt="" + aria-hidden="true"):
+ *   - /media/ingenium/illustrations/flores-corazon.png (components/sections/FloralSeparator.tsx)
+ *   - /media/ingenium/illustrations/flor-sola.png (components/FloralDecor.tsx)
+ *   - /media/ingenium/illustrations/flores-dos.png (components/FloralDecor.tsx)
+ *   - /media/ingenium/illustrations/corazon.png (components/FloralDecor.tsx)
+ *   - /media/ingenium/illustrations/flores-corazon.png (components/FloralDecor.tsx)
+ *   - /media/ingenium/icons/flor-sola.png (components/FloralDecor.tsx)
+ *   - /media/ingenium/icons/flores-dos.png (components/FloralDecor.tsx)
+ *   - /media/ingenium/icons/corazon.png (components/FloralDecor.tsx)
+ *
+ * Assets en public no referenciados:
+ * - /next.svg
+ * - /vercel.svg
+ * - /window.svg
+ * - /globe.svg
+ * - /file.svg
+ * - /mock/maqueta_Ingenium.png
+ * - /mock/inspiracion_maqueta_01.jpg
+ * - /mock/inspiracion_maqueta_02.jpg
+ * - /media/ingenium/people/audience-1.svg
+ * - /media/ingenium/people/audience-2.svg
+ * - /media/ingenium/people/audience-3.svg
+ * - /media/ingenium/people/audience-4.svg
+ * - /media/ingenium/people/hero.svg
+ * - /media/ingenium/illustrations/hero-learning-accompaniment_1_soft.png
+ * - /media/ingenium/illustrations/hero-learning-accompaniment_1_origen.png
+ * - /media/ingenium/illustrations/audience-learning-process_old.png
+ * - /media/ingenium/illustrations/audience-learning-process_2.png
+ */


### PR DESCRIPTION
### Motivation

- Capture and centralize the accessibility decisions for all UI images without changing visuals or behavior.  
- Provide a clear mapping of which images are decorative vs significant and where `alt`/`aria` were applied.  
- Surface public assets that are present but not referenced so they can be reviewed later.  

### Description

- Added a documentation comment to `content/ingenium.media.ts` summarizing image accessibility decisions and the specific `alt` / `aria-hidden` usage per component.  
- The comment lists significant images (with the descriptive `alt` used, e.g. hero image in `components/sections/Hero.tsx`) and decorative images (with `alt=""` and `aria-hidden="true"` used in components such as `FloralSeparator` and `FloralDecor`).  
- The comment also enumerates public assets under `public/` that are not referenced anywhere in the codebase for follow-up.  
- No visual, layout, import, or runtime code behavior was changed; this is documentation-only.  

### Testing

- No automated tests were executed because this is a documentation-only change.  
- The change is limited to a comment in `content/ingenium.media.ts` and does not modify runtime code paths, so no build impact is expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958ff898388832db9dde0e3d2cd601e)