### PR TITLE
Update landing: structured sections, sticky nav, FAQ, and smooth scrolling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -119,6 +119,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    scroll-behavior: smooth;
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,52 @@
 import { FloralDecor, PaperBackground } from "@/components/FloralDecor";
 import Audience from "@/components/sections/Audience";
-import Conditions from "@/components/sections/Conditions";
 import ContactCTA from "@/components/sections/ContactCTA";
+import Faq from "@/components/sections/Faq";
+import FamiliesSchools from "@/components/sections/FamiliesSchools";
 import FloralSeparator from "@/components/sections/FloralSeparator";
 import Hero from "@/components/sections/Hero";
-import HowWeWork from "@/components/sections/HowWeWork";
+import InitialInterview from "@/components/sections/InitialInterview";
+import PedagogicalFocus from "@/components/sections/PedagogicalFocus";
+import Proposals from "@/components/sections/Proposals";
+import SmallGroups from "@/components/sections/SmallGroups";
+import StickyNav from "@/components/sections/StickyNav";
+import Technology from "@/components/sections/Technology";
 
 export default function Home() {
   return (
     <div className="min-h-screen bg-paper text-[#3f2f20]">
       <main>
+        <StickyNav />
         <PaperBackground variant="hero" allowOverflow>
           <FloralDecor variant="leftTop" />
           <Hero />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="leftMid" />
-          <HowWeWork />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
           <Audience />
         </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <PedagogicalFocus />
+        </PaperBackground>
         <FloralSeparator />
-        <Conditions />
+        <PaperBackground variant="section" allowOverflow>
+          <Proposals />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <SmallGroups />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <FamiliesSchools />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <Technology />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <InitialInterview />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <Faq />
+        </PaperBackground>
         <ContactCTA />
       </main>
     </div>

--- a/components/sections/Audience.tsx
+++ b/components/sections/Audience.tsx
@@ -1,10 +1,10 @@
-import { ingeniumCopy } from "@/content/ingenium.copy";
 import Section from "@/components/ui/Section";
 import { ingeniumMedia } from "@/content/ingenium.media";
+import { ingeniumSections } from "@/data/ingeniumSections";
 import Image from "next/image";
 
 export default function Audience() {
-  const { audience } = ingeniumCopy;
+  const { how } = ingeniumSections.sections;
   const audienceImages = [
     ingeniumMedia.audience.primary,
     ingeniumMedia.audience.secondary,
@@ -13,16 +13,19 @@ export default function Audience() {
   ];
 
   return (
-    <Section id="para-quien">
+    <Section id={how.id}>
       <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
         <div className="space-y-10">
-          <div className="text-center">
+          <div className="space-y-4 text-center">
             <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
-              {audience.title}
+              {how.title}
             </h2>
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {how.body}
+            </p>
           </div>
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-            {audience.items.map((item, index) => (
+            {how.items?.map((item, index) => (
               <div
                 key={item.title}
                 className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-5 shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
@@ -47,6 +50,19 @@ export default function Audience() {
               </div>
             ))}
           </div>
+          {how.ctas?.length ? (
+            <div className="flex justify-center">
+              {how.ctas.map((cta) => (
+                <a
+                  key={cta.label}
+                  href={cta.href}
+                  className="inline-flex items-center justify-center rounded-full border border-[#d9c3a1] bg-white/80 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] sm:text-base"
+                >
+                  {cta.label}
+                </a>
+              ))}
+            </div>
+          ) : null}
         </div>
       </div>
     </Section>

--- a/components/sections/FamiliesSchools.tsx
+++ b/components/sections/FamiliesSchools.tsx
@@ -1,0 +1,24 @@
+import Section from "@/components/ui/Section";
+import { ingeniumSections } from "@/data/ingeniumSections";
+
+export default function FamiliesSchools() {
+  const { families } = ingeniumSections.sections;
+
+  return (
+    <Section id={families.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-4">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {families.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {families.body}
+          </p>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {families.subtitle}
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Faq.tsx
+++ b/components/sections/Faq.tsx
@@ -1,0 +1,33 @@
+import Section from "@/components/ui/Section";
+import { ingeniumSections } from "@/data/ingeniumSections";
+
+export default function Faq() {
+  const { faq } = ingeniumSections;
+
+  return (
+    <Section id={faq.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-8">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {faq.title}
+          </h2>
+          <div className="space-y-4">
+            {faq.items.map((item) => (
+              <details
+                key={item.question}
+                className="group rounded-[1.75rem] border border-[#eadfce] bg-white/90 p-5 shadow-[0_10px_25px_rgba(157,121,68,0.1)]"
+              >
+                <summary className="cursor-pointer list-none text-sm font-semibold text-[#4a3725] sm:text-base">
+                  {item.question}
+                </summary>
+                <p className="mt-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
+                  {item.answer}
+                </p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,10 +1,10 @@
-import { ingeniumCopy } from "@/content/ingenium.copy";
 import Section from "@/components/ui/Section";
 import { ingeniumMedia } from "@/content/ingenium.media";
+import { ingeniumSections } from "@/data/ingeniumSections";
 import Image from "next/image";
 
 export default function Hero() {
-  const { brand, hero } = ingeniumCopy;
+  const { hero } = ingeniumSections;
 
   return (
     <Section className="pt-16 sm:pt-24">
@@ -13,31 +13,28 @@ export default function Hero() {
           <div className="space-y-6">
             <div className="space-y-3">
               <h1 className="text-3xl font-semibold uppercase tracking-[0.25em] text-[#B88A3B] sm:text-4xl lg:text-5xl">
-                {brand.name}
+                {hero.brand}
               </h1>
               <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl lg:text-4xl">
                 {hero.title}
               </h2>
               <p className="text-base leading-relaxed text-[#5c4a36] sm:text-lg">
-                {hero.subtitle}
+                {hero.body}
               </p>
             </div>
             <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
-              {brand.intro}
+              {hero.microText}
             </p>
             <div className="flex flex-col gap-3 sm:flex-row">
-              <a
-                href={hero.ctaPrimary.href}
-                className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/25 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
-              >
-                {hero.ctaPrimary.label}
-              </a>
-              <a
-                href={hero.ctaSecondary.href}
-                className="inline-flex w-full items-center justify-center rounded-full border border-[#d9c3a1] bg-white/80 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] sm:w-auto sm:text-base"
-              >
-                {hero.ctaSecondary.label}
-              </a>
+              {hero.ctas.map((cta) => (
+                <a
+                  key={cta.label}
+                  href={cta.href}
+                  className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/25 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+                >
+                  {cta.label}
+                </a>
+              ))}
             </div>
           </div>
           <div className="relative">

--- a/components/sections/InitialInterview.tsx
+++ b/components/sections/InitialInterview.tsx
@@ -1,0 +1,44 @@
+import Section from "@/components/ui/Section";
+import { ingeniumSections } from "@/data/ingeniumSections";
+
+export default function InitialInterview() {
+  const { interview } = ingeniumSections.sections;
+
+  return (
+    <Section id={interview.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-6">
+          <div className="space-y-3">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {interview.title}
+            </h2>
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {interview.body}
+            </p>
+          </div>
+          <ul className="grid gap-3 text-sm leading-relaxed text-[#6a5743] sm:grid-cols-2 sm:text-base">
+            {interview.bullets?.map((bullet) => (
+              <li key={bullet} className="flex gap-3">
+                <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+          {interview.ctas?.length ? (
+            <div className="flex flex-wrap gap-3">
+              {interview.ctas.map((cta) => (
+                <a
+                  key={cta.label}
+                  href={cta.href}
+                  className="inline-flex items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/25 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:text-base"
+                >
+                  {cta.label}
+                </a>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/PedagogicalFocus.tsx
+++ b/components/sections/PedagogicalFocus.tsx
@@ -1,0 +1,29 @@
+import Section from "@/components/ui/Section";
+import { ingeniumSections } from "@/data/ingeniumSections";
+
+export default function PedagogicalFocus() {
+  const { approach } = ingeniumSections.sections;
+
+  return (
+    <Section id={approach.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-6">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {approach.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {approach.body}
+          </p>
+          <ul className="grid gap-3 text-sm leading-relaxed text-[#6a5743] sm:grid-cols-2 sm:text-base">
+            {approach.bullets?.map((bullet) => (
+              <li key={bullet} className="flex gap-3">
+                <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Proposals.tsx
+++ b/components/sections/Proposals.tsx
@@ -1,0 +1,60 @@
+import Section from "@/components/ui/Section";
+import { ingeniumSections } from "@/data/ingeniumSections";
+
+export default function Proposals() {
+  const { proposals } = ingeniumSections.sections;
+
+  return (
+    <Section id={proposals.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-8">
+          <div className="space-y-3">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {proposals.title}
+            </h2>
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {proposals.body}
+            </p>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-3">
+            {proposals.items?.map((item) => (
+              <div
+                key={item.title}
+                className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
+              >
+                <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                  {item.title}
+                </h3>
+                {item.details?.length ? (
+                  <ul className="space-y-2 text-sm leading-relaxed text-[#6a5743]">
+                    {item.details.map((detail) => (
+                      <li key={detail} className="flex gap-3">
+                        <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                        <span>{detail}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+                {item.bullets?.length ? (
+                  <ul className="space-y-2 text-sm leading-relaxed text-[#6a5743]">
+                    {item.bullets.map((bullet) => (
+                      <li key={bullet} className="flex gap-3">
+                        <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                        <span>{bullet}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+                {item.body ? (
+                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                    {item.body}
+                  </p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/SmallGroups.tsx
+++ b/components/sections/SmallGroups.tsx
@@ -1,0 +1,29 @@
+import Section from "@/components/ui/Section";
+import { ingeniumSections } from "@/data/ingeniumSections";
+
+export default function SmallGroups() {
+  const { groups } = ingeniumSections.sections;
+
+  return (
+    <Section id={groups.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 text-center shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-6">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {groups.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {groups.body}
+          </p>
+          <ul className="space-y-2 text-sm font-semibold text-[#4a3725] sm:text-base">
+            {groups.bullets?.map((bullet) => (
+              <li key={bullet}>{bullet}</li>
+            ))}
+          </ul>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {groups.subtitle}
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/StickyNav.tsx
+++ b/components/sections/StickyNav.tsx
@@ -1,0 +1,23 @@
+import { ingeniumSections } from "@/data/ingeniumSections";
+import { cn } from "@/lib/utils";
+
+export default function StickyNav() {
+  return (
+    <div className="sticky top-0 z-50 border-b border-[#eadfce] bg-white/85 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center gap-3 px-6 py-3 sm:gap-4">
+        {ingeniumSections.nav.map((item) => (
+          <a
+            key={item.id}
+            href={`#${item.id}`}
+            className={cn(
+              "rounded-full px-4 py-2 text-xs font-semibold text-[#6a5743] transition hover:text-[#B88A3B]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#B88A3B]/40",
+            )}
+          >
+            {item.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/sections/Technology.tsx
+++ b/components/sections/Technology.tsx
@@ -1,0 +1,21 @@
+import Section from "@/components/ui/Section";
+import { ingeniumSections } from "@/data/ingeniumSections";
+
+export default function Technology() {
+  const { technology } = ingeniumSections.sections;
+
+  return (
+    <Section id={technology.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-4">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {technology.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {technology.body}
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -12,7 +12,10 @@ export default function Section({ id, className, children }: SectionProps) {
   return (
     <section
       id={id}
-      className={cn("px-6 py-16 sm:py-24 lg:py-28", className)}
+      className={cn(
+        "scroll-mt-24 px-6 py-16 sm:scroll-mt-28 sm:py-24 lg:scroll-mt-32 lg:py-28",
+        className,
+      )}
     >
       <div className="mx-auto w-full max-w-6xl">{children}</div>
     </section>

--- a/data/ingeniumSections.ts
+++ b/data/ingeniumSections.ts
@@ -1,0 +1,232 @@
+import { ingeniumContact } from "@/lib/contact";
+
+export type SectionCTA = {
+  label: string;
+  href: string;
+  variant?: "primary" | "secondary";
+};
+
+export type SectionItem = {
+  title: string;
+  body?: string;
+  details?: string[];
+  bullets?: string[];
+};
+
+export type IngeniumSection = {
+  id: string;
+  navLabel: string;
+  title: string;
+  subtitle?: string;
+  body?: string | string[];
+  items?: SectionItem[];
+  bullets?: string[];
+  ctas?: SectionCTA[];
+};
+
+export type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+export const ingeniumSections = {
+  hero: {
+    brand: "INGENIUM",
+    title: "Acompañamiento educativo",
+    body:
+      "Un espacio para aprender a organizarse por dentro: hábitos de estudio, comprensión, autonomía y calma en los momentos que más pesan.",
+    microText:
+      "No es solo apoyo escolar: acompañamos trayectorias, con criterio pedagógico y seguimiento cercano.",
+    ctas: [
+      {
+        label: "Consultar por WhatsApp",
+        href: ingeniumContact.whatsappUrl,
+        variant: "primary",
+      },
+    ],
+  },
+  nav: [
+    { id: "como-acompana", label: "Cómo acompaña" },
+    { id: "propuestas", label: "Propuestas" },
+    { id: "grupos-reducidos", label: "Grupos reducidos" },
+    { id: "familias-escuelas", label: "Familias y escuelas" },
+    { id: "contacto", label: "Contacto" },
+  ],
+  sections: {
+    how: {
+      id: "como-acompana",
+      navLabel: "Cómo acompaña",
+      title: "Cómo acompaña Ingenium",
+      body:
+        "Cada proceso necesita un tipo de acompañamiento. Estas son las situaciones más comunes con las que llegan familias, estudiantes y también escuelas.",
+      items: [
+        {
+          title: "Sostener el estudio",
+          body:
+            "Cuando hay esfuerzo, pero los resultados no aparecen. Trabajamos comprensión, método y constancia, sin correr atrás de la tarea.",
+        },
+        {
+          title: "Organización y planificación",
+          body:
+            "Cuando todo se hace a último momento y estudiar se vuelve caos. Ordenamos rutinas, prioridades y herramientas para que el estudio sea manejable.",
+        },
+        {
+          title: "Instancias exigentes",
+          body:
+            "Previas, ingresos, exámenes, cambios de ritmo. Acompañamiento intensivo con organización del estudio y manejo del estrés académico.",
+        },
+        {
+          title: "Trayectorias en transición",
+          body:
+            "Cambios de nivel, repitencia, desmotivación, bloqueos. Reconstruimos el proceso paso a paso, con acuerdos claros y acompañamiento real.",
+        },
+      ],
+      ctas: [
+        {
+          label: "Contanos tu situación y te decimos cuál es el mejor camino.",
+          href: ingeniumContact.whatsappUrl,
+          variant: "secondary",
+        },
+      ],
+    },
+    approach: {
+      id: "enfoque",
+      navLabel: "Enfoque",
+      title: "Enfoque pedagógico",
+      body:
+        "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
+      bullets: [
+        "Hábitos de estudio sostenidos",
+        "Organización y jerarquización de actividades",
+        "Comprensión e interpretación (no memorización vacía)",
+        "Manejo del estrés y cuidado del clima emocional",
+        "Tecnología como herramienta (con criterio, no uso pasivo)",
+        "Articulación alumno–familia–escuela",
+      ],
+    },
+    proposals: {
+      id: "propuestas",
+      navLabel: "Propuestas",
+      title: "Propuestas",
+      body:
+        "No vendemos ‘paquetes’. Definimos la propuesta en una entrevista inicial según la necesidad real.",
+      items: [
+        {
+          title: "Acompañamiento sostenido (Apoyo escolar)",
+          details: [
+            "Primaria y secundaria.",
+            "Individual o grupal.",
+            "Contenidos escolares + hábitos + organización + comprensión.",
+          ],
+        },
+        {
+          title: "Momentos de exigencia (previas e ingresos)",
+          bullets: [
+            "Preparación de materias pendientes (febrero / marzo)",
+            "Ingresos a colegios con examen",
+            "Preparación preuniversitaria",
+          ],
+          body:
+            "Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
+        },
+        {
+          title: "Cursos y talleres (duración acotada, enfoque práctico)",
+          bullets: [
+            "Técnicas de estudio",
+            "Organización y planificación",
+            "Comprensión lectora",
+            "Razonamiento matemático",
+            "Acompañamiento en momentos críticos",
+          ],
+          body:
+            "Grupos reducidos, contenidos focalizados y práctica guiada.",
+        },
+      ],
+    },
+    groups: {
+      id: "grupos-reducidos",
+      navLabel: "Grupos reducidos",
+      title: "Grupos reducidos",
+      body:
+        "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
+      bullets: ["Primaria: hasta 3 estudiantes", "Secundaria: hasta 4 estudiantes"],
+      subtitle:
+        "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
+    },
+    families: {
+      id: "familias-escuelas",
+      navLabel: "Familias y escuelas",
+      title: "Familias y escuelas",
+      body:
+        "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
+      subtitle:
+        "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
+    },
+    technology: {
+      id: "tecnologia",
+      navLabel: "Tecnología",
+      title: "Tecnología con criterio",
+      body:
+        "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
+    },
+    interview: {
+      id: "entrevista",
+      navLabel: "Entrevista inicial",
+      title: "Entrevista inicial",
+      body:
+        "Para cuidar el proceso, primero escuchamos la situación y definimos un camino posible: modalidad, frecuencia, objetivos y acuerdos.",
+      bullets: [
+        "Etapa escolar/formativa",
+        "Organización actual y hábitos",
+        "Nivel de comprensión / método",
+        "Estrés y contexto",
+        "Uso de tecnología",
+        "Expectativas de la familia",
+      ],
+      ctas: [
+        {
+          label: "Consultar por WhatsApp",
+          href: ingeniumContact.whatsappUrl,
+          variant: "primary",
+        },
+      ],
+    },
+  },
+  faq: {
+    id: "faq",
+    navLabel: "FAQ",
+    title: "FAQ",
+    items: [
+      {
+        question: "¿Ingenium es solo para chicos?",
+        answer:
+          "No. Acompañamos trayectorias escolares y formativas en distintos momentos (incluye ingresos y etapas exigentes).",
+      },
+      {
+        question: "¿Trabajan por materias?",
+        answer:
+          "Trabajamos contenidos, sí, pero el eje es el proceso: método, comprensión, organización y autonomía.",
+      },
+      {
+        question: "¿Individual o grupal?",
+        answer:
+          "Depende de la necesidad. Si es grupal, siempre es reducido (primaria 3, secundaria 4).",
+      },
+      {
+        question: "¿Cómo manejan previas e ingresos?",
+        answer:
+          "Como momentos críticos: acompañamiento intensivo + planificación + manejo del estrés.",
+      },
+      {
+        question: "¿La familia participa?",
+        answer:
+          "Sí: comunicación clara y acuerdos para sostener hábitos fuera del espacio.",
+      },
+      {
+        question: "¿Cómo se define la propuesta?",
+        answer:
+          "En la entrevista inicial, según la trayectoria y el momento.",
+      },
+    ] satisfies FaqItem[],
+  },
+} as const;


### PR DESCRIPTION
### Motivation
- Provide a single, typed source of truth for the new Ingenium landing content and copy by sections.  
- Reorder and render the landing sections to match the new “esqueleto por secciones” without changing visual branding or contact/SEO content.  
- Add a minimal sticky anchor navigation and smooth anchor scrolling for easier section access.  
- Insert a concise FAQ block before the contact section to address common questions.

### Description
- Add `data/ingeniumSections.ts` exporting typed section content, CTAs and FAQ items used across the landing.  
- Implement new section components and refactor existing ones (Hero, Audience) to render from `ingeniumSections`, and add `PedagogicalFocus`, `Proposals`, `SmallGroups`, `FamiliesSchools`, `Technology`, `InitialInterview`, `Faq`, and `StickyNav`.  
- Update `app/page.tsx` to render sections in the requested order and keep the existing contact block unchanged with `id="contacto"`.  
- Enable smooth anchor scrolling by adding `scroll-behavior: smooth` in `app/globals.css` and adjust `Section` to include appropriate `scroll-mt` values for sticky nav spacing.

### Testing
- Started the dev server with `npm run dev` and loaded the homepage successfully (GET `/` returned 200).  
- Captured an automated Playwright screenshot of the running site for visual review (`artifacts/ingenium-home.png`).  
- Next.js logged Google Fonts fetch warnings during startup and fell back to local fonts, but the app compiled and rendered (font download warnings are external and not blocking).  
- No new runtime errors were observed during the automated page load and screenshot step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590843f0dc832d80ccf99a8f867dd7)