### PR TITLE
Add structured Ingenium sections, sticky anchor nav, FAQ and wire into landing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -119,6 +119,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    scroll-behavior: smooth;
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,31 @@
 import { FloralDecor, PaperBackground } from "@/components/FloralDecor";
-import Audience from "@/components/sections/Audience";
-import Conditions from "@/components/sections/Conditions";
 import ContactCTA from "@/components/sections/ContactCTA";
 import FloralSeparator from "@/components/sections/FloralSeparator";
 import Hero from "@/components/sections/Hero";
-import HowWeWork from "@/components/sections/HowWeWork";
+import IngeniumSectionRenderer from "@/components/sections/IngeniumSectionRenderer";
+import StickyNav from "@/components/sections/StickyNav";
+import { ingeniumSections } from "@/data/ingeniumSections";
 
 export default function Home() {
+  const mainSections = ingeniumSections.filter((section) => section.id !== "faq");
+  const faqSection = ingeniumSections.find((section) => section.id === "faq");
+
   return (
     <div className="min-h-screen bg-paper text-[#3f2f20]">
       <main>
+        <StickyNav />
         <PaperBackground variant="hero" allowOverflow>
           <FloralDecor variant="leftTop" />
           <Hero />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="leftMid" />
-          <HowWeWork />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
-          <Audience />
+          {mainSections.map((section) => (
+            <IngeniumSectionRenderer key={section.id} section={section} />
+          ))}
+          {faqSection && <IngeniumSectionRenderer section={faqSection} />}
         </PaperBackground>
         <FloralSeparator />
-        <Conditions />
         <ContactCTA />
       </main>
     </div>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,10 +1,11 @@
-import { ingeniumCopy } from "@/content/ingenium.copy";
 import Section from "@/components/ui/Section";
 import { ingeniumMedia } from "@/content/ingenium.media";
+import { ingeniumHero } from "@/data/ingeniumSections";
+import { cn } from "@/lib/utils";
 import Image from "next/image";
 
 export default function Hero() {
-  const { brand, hero } = ingeniumCopy;
+  const { heading, subheading, body, microtext, ctas } = ingeniumHero;
 
   return (
     <Section className="pt-16 sm:pt-24">
@@ -13,31 +14,33 @@ export default function Hero() {
           <div className="space-y-6">
             <div className="space-y-3">
               <h1 className="text-3xl font-semibold uppercase tracking-[0.25em] text-[#B88A3B] sm:text-4xl lg:text-5xl">
-                {brand.name}
+                {heading}
               </h1>
               <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl lg:text-4xl">
-                {hero.title}
+                {subheading}
               </h2>
               <p className="text-base leading-relaxed text-[#5c4a36] sm:text-lg">
-                {hero.subtitle}
+                {body}
               </p>
             </div>
             <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
-              {brand.intro}
+              {microtext}
             </p>
             <div className="flex flex-col gap-3 sm:flex-row">
-              <a
-                href={hero.ctaPrimary.href}
-                className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/25 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
-              >
-                {hero.ctaPrimary.label}
-              </a>
-              <a
-                href={hero.ctaSecondary.href}
-                className="inline-flex w-full items-center justify-center rounded-full border border-[#d9c3a1] bg-white/80 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] sm:w-auto sm:text-base"
-              >
-                {hero.ctaSecondary.label}
-              </a>
+              {ctas.map((cta) => (
+                <a
+                  key={cta.label}
+                  href={cta.href}
+                  className={cn(
+                    "inline-flex w-full items-center justify-center rounded-full px-6 py-3 text-sm font-semibold shadow-md transition hover:-translate-y-0.5 sm:w-auto sm:text-base",
+                    cta.variant === "secondary"
+                      ? "border border-[#d9c3a1] bg-white/80 text-[#6b4d25] shadow-sm hover:border-[#cfae7a]"
+                      : "bg-[#B88A3B] text-white shadow-[#B88A3B]/25 hover:bg-[#a97c33]",
+                  )}
+                >
+                  {cta.label}
+                </a>
+              ))}
             </div>
           </div>
           <div className="relative">

--- a/components/sections/IngeniumSectionRenderer.tsx
+++ b/components/sections/IngeniumSectionRenderer.tsx
@@ -1,0 +1,250 @@
+import { FloralIcon } from "@/components/FloralDecor";
+import Section from "@/components/ui/Section";
+import type { IngeniumSection, SectionCTA } from "@/data/ingeniumSections";
+import { cn } from "@/lib/utils";
+
+const iconByIndex = ["flor", "flores", "corazon"] as const;
+
+const ctaClassName = (variant?: SectionCTA["variant"]) =>
+  variant === "secondary"
+    ? "inline-flex w-full items-center justify-center rounded-full border border-[#d9c3a1] bg-white/80 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] sm:w-auto sm:text-base"
+    : "inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/25 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base";
+
+const renderBody = (body?: IngeniumSection["body"], className?: string) => {
+  if (!body) return null;
+  const paragraphs = Array.isArray(body) ? body : [body];
+
+  return paragraphs.map((text) => (
+    <p
+      key={text}
+      className={cn("text-sm leading-relaxed text-[#6a5743] sm:text-base", className)}
+    >
+      {text}
+    </p>
+  ));
+};
+
+export default function IngeniumSectionRenderer({
+  section,
+}: {
+  section: IngeniumSection;
+}) {
+  switch (section.variant) {
+    case "cards": {
+      return (
+        <Section id={section.id}>
+          <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+            <div className="space-y-10">
+              <div className="space-y-3 text-center">
+                <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+                  {section.title}
+                </h2>
+                {section.body && (
+                  <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+                    {section.body}
+                  </p>
+                )}
+              </div>
+              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+                {section.items?.map((item, index) => (
+                  <div
+                    key={item.title}
+                    className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
+                  >
+                    <FloralIcon icon={iconByIndex[index % iconByIndex.length]} />
+                    <div className="space-y-3">
+                      <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                        {item.title}
+                      </h3>
+                      {item.body && (
+                        <p className="text-sm leading-relaxed text-[#6a5743]">
+                          {item.body}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              {section.ctas && section.ctas.length > 0 && (
+                <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                  {section.ctas.map((cta) => (
+                    <a
+                      key={cta.label}
+                      href={cta.href}
+                      className={ctaClassName(cta.variant)}
+                    >
+                      {cta.label}
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </Section>
+      );
+    }
+    case "bullets": {
+      return (
+        <Section id={section.id}>
+          <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+            <div className="space-y-6">
+              <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+                {section.title}
+              </h2>
+              {renderBody(section.body)}
+              <ul className="space-y-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
+                {section.items?.map((item) => (
+                  <li key={item.title} className="flex gap-3">
+                    <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                    <span>{item.title}</span>
+                  </li>
+                ))}
+              </ul>
+              {section.ctas && section.ctas.length > 0 && (
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  {section.ctas.map((cta) => (
+                    <a
+                      key={cta.label}
+                      href={cta.href}
+                      className={ctaClassName(cta.variant)}
+                    >
+                      {cta.label}
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </Section>
+      );
+    }
+    case "proposals": {
+      return (
+        <Section id={section.id}>
+          <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+            <div className="space-y-8">
+              <div className="space-y-3">
+                <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+                  {section.title}
+                </h2>
+                {section.body && (
+                  <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+                    {section.body}
+                  </p>
+                )}
+              </div>
+              <div className="grid gap-6 lg:grid-cols-3">
+                {section.items?.map((item) => (
+                  <div
+                    key={item.title}
+                    className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
+                  >
+                    <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                      {item.title}
+                    </h3>
+                    {item.details && (
+                      <div className="space-y-2 text-sm text-[#6a5743]">
+                        {item.details.map((detail) => (
+                          <p key={detail.label}>
+                            <span className="font-semibold text-[#4a3725]">
+                              {detail.label}
+                            </span>{" "}
+                            {detail.value}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+                    {item.list && (
+                      <ul className="space-y-2 text-sm leading-relaxed text-[#6a5743]">
+                        {item.list.map((entry) => (
+                          <li key={entry} className="flex gap-3">
+                            <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                            <span>{entry}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    {item.body && (
+                      <p className="text-sm leading-relaxed text-[#6a5743]">
+                        {item.body}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+      );
+    }
+    case "text-list": {
+      return (
+        <Section id={section.id}>
+          <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+            <div className="space-y-6">
+              <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+                {section.title}
+              </h2>
+              {renderBody(section.body)}
+              {section.items && (
+                <ul className="space-y-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
+                  {section.items.map((item) => (
+                    <li key={item.title} className="flex gap-3">
+                      <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                      <span>{item.title}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </Section>
+      );
+    }
+    case "faq": {
+      return (
+        <Section id={section.id}>
+          <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+            <div className="space-y-8">
+              <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+                {section.title}
+              </h2>
+              <div className="grid gap-6 md:grid-cols-2">
+                {section.items?.map((item) => (
+                  <div
+                    key={item.title}
+                    className="flex h-full flex-col gap-3 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
+                  >
+                    <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                      {item.title}
+                    </h3>
+                    {item.body && (
+                      <p className="text-sm leading-relaxed text-[#6a5743]">
+                        {item.body}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+      );
+    }
+    case "text":
+    default: {
+      return (
+        <Section id={section.id}>
+          <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+            <div className="space-y-4">
+              <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+                {section.title}
+              </h2>
+              {renderBody(section.body)}
+            </div>
+          </div>
+        </Section>
+      );
+    }
+  }
+}

--- a/components/sections/StickyNav.tsx
+++ b/components/sections/StickyNav.tsx
@@ -1,0 +1,24 @@
+import { ingeniumNav } from "@/data/ingeniumSections";
+
+export default function StickyNav() {
+  return (
+    <div className="sticky top-0 z-30 border-b border-[#eadfce] bg-paper/85 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-center px-6 py-3">
+        <nav aria-label="Navegación principal">
+          <ul className="flex flex-wrap items-center justify-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#6a5743] sm:gap-3 sm:text-sm">
+            {ingeniumNav.map((item) => (
+              <li key={item.id}>
+                <a
+                  href={`#${item.id}`}
+                  className="rounded-full border border-transparent px-3 py-1 transition hover:border-[#d9c3a1] hover:bg-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#B88A3B]"
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/data/ingeniumSections.ts
+++ b/data/ingeniumSections.ts
@@ -1,0 +1,245 @@
+import { ingeniumContact } from "@/lib/contact";
+
+export type SectionCTA = {
+  label: string;
+  href: string;
+  variant?: "primary" | "secondary";
+};
+
+export type SectionDetail = {
+  label: string;
+  value: string;
+};
+
+export type SectionItem = {
+  title: string;
+  body?: string;
+  list?: string[];
+  details?: SectionDetail[];
+};
+
+export type SectionVariant =
+  | "cards"
+  | "bullets"
+  | "proposals"
+  | "text"
+  | "text-list"
+  | "faq";
+
+export type IngeniumSection = {
+  id: string;
+  navLabel?: string;
+  title: string;
+  subtitle?: string;
+  body?: string | string[];
+  items?: SectionItem[];
+  ctas?: SectionCTA[];
+  variant: SectionVariant;
+};
+
+export const ingeniumHero = {
+  heading: "INGENIUM",
+  subheading: "Acompañamiento educativo",
+  body:
+    "Un espacio para aprender a organizarse por dentro: hábitos de estudio, comprensión, autonomía y calma en los momentos que más pesan.",
+  microtext:
+    "No es solo apoyo escolar: acompañamos trayectorias, con criterio pedagógico y seguimiento cercano.",
+  ctas: [
+    {
+      label: "Consultar por WhatsApp",
+      href: ingeniumContact.whatsappUrl,
+      variant: "primary",
+    },
+  ],
+} as const;
+
+export const ingeniumNav = [
+  { id: "como-acompana", label: "Cómo acompaña" },
+  { id: "propuestas", label: "Propuestas" },
+  { id: "grupos-reducidos", label: "Grupos reducidos" },
+  { id: "familias-escuelas", label: "Familias y escuelas" },
+  { id: "contacto", label: "Contacto" },
+] as const;
+
+export const ingeniumSections: IngeniumSection[] = [
+  {
+    id: "como-acompana",
+    navLabel: "Cómo acompaña",
+    title: "Cómo acompaña Ingenium",
+    body:
+      "Cada proceso necesita un tipo de acompañamiento. Estas son las situaciones más comunes con las que llegan familias, estudiantes y también escuelas.",
+    items: [
+      {
+        title: "Sostener el estudio",
+        body: "Cuando hay esfuerzo, pero los resultados no aparecen. Trabajamos comprensión, método y constancia, sin correr atrás de la tarea.",
+      },
+      {
+        title: "Organización y planificación",
+        body: "Cuando todo se hace a último momento y estudiar se vuelve caos. Ordenamos rutinas, prioridades y herramientas para que el estudio sea manejable.",
+      },
+      {
+        title: "Instancias exigentes",
+        body: "Previas, ingresos, exámenes, cambios de ritmo. Acompañamiento intensivo con organización del estudio y manejo del estrés académico.",
+      },
+      {
+        title: "Trayectorias en transición",
+        body: "Cambios de nivel, repitencia, desmotivación, bloqueos. Reconstruimos el proceso paso a paso, con acuerdos claros y acompañamiento real.",
+      },
+    ],
+    ctas: [
+      {
+        label: "Contanos tu situación y te decimos cuál es el mejor camino.",
+        href: ingeniumContact.whatsappUrl,
+        variant: "primary",
+      },
+    ],
+    variant: "cards",
+  },
+  {
+    id: "enfoque",
+    title: "Enfoque pedagógico",
+    body:
+      "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
+    items: [
+      { title: "Hábitos de estudio sostenidos" },
+      { title: "Organización y jerarquización de actividades" },
+      { title: "Comprensión e interpretación (no memorización vacía)" },
+      { title: "Manejo del estrés y cuidado del clima emocional" },
+      { title: "Tecnología como herramienta (con criterio, no uso pasivo)" },
+      { title: "Articulación alumno–familia–escuela" },
+    ],
+    variant: "bullets",
+  },
+  {
+    id: "propuestas",
+    navLabel: "Propuestas",
+    title: "Propuestas",
+    body:
+      "No vendemos ‘paquetes’. Definimos la propuesta en una entrevista inicial según la necesidad real.",
+    items: [
+      {
+        title: "Acompañamiento sostenido (Apoyo escolar)",
+        details: [
+          { label: "Para quién:", value: "Primaria y secundaria." },
+          { label: "Modalidades:", value: "Individual o grupal." },
+          {
+            label: "Enfoque:",
+            value:
+              "Contenidos escolares + hábitos + organización + comprensión.",
+          },
+        ],
+      },
+      {
+        title: "Momentos de exigencia (previas e ingresos)",
+        list: [
+          "Preparación de materias pendientes (febrero / marzo)",
+          "Ingresos a colegios con examen",
+          "Preparación preuniversitaria",
+        ],
+        body:
+          "Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
+      },
+      {
+        title: "Cursos y talleres (duración acotada, enfoque práctico)",
+        list: [
+          "Técnicas de estudio",
+          "Organización y planificación",
+          "Comprensión lectora",
+          "Razonamiento matemático",
+          "Acompañamiento en momentos críticos",
+        ],
+        body: "Grupos reducidos, contenidos focalizados y práctica guiada.",
+      },
+    ],
+    variant: "proposals",
+  },
+  {
+    id: "grupos-reducidos",
+    navLabel: "Grupos reducidos",
+    title: "Grupos reducidos",
+    body: [
+      "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
+      "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
+    ],
+    items: [
+      { title: "Primaria: hasta 3 estudiantes" },
+      { title: "Secundaria: hasta 4 estudiantes" },
+    ],
+    variant: "text-list",
+  },
+  {
+    id: "familias-escuelas",
+    navLabel: "Familias y escuelas",
+    title: "Familias y escuelas",
+    body: [
+      "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
+      "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
+    ],
+    variant: "text",
+  },
+  {
+    id: "tecnologia",
+    title: "Tecnología con criterio",
+    body:
+      "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
+    variant: "text",
+  },
+  {
+    id: "entrevista",
+    title: "Entrevista inicial",
+    body:
+      "Para cuidar el proceso, primero escuchamos la situación y definimos un camino posible: modalidad, frecuencia, objetivos y acuerdos.",
+    items: [
+      { title: "Etapa escolar/formativa" },
+      { title: "Organización actual y hábitos" },
+      { title: "Nivel de comprensión / método" },
+      { title: "Estrés y contexto" },
+      { title: "Uso de tecnología" },
+      { title: "Expectativas de la familia" },
+    ],
+    ctas: [
+      {
+        label: "Consultar por WhatsApp",
+        href: ingeniumContact.whatsappUrl,
+        variant: "primary",
+      },
+    ],
+    variant: "bullets",
+  },
+  {
+    id: "faq",
+    title: "FAQ",
+    items: [
+      {
+        title: "¿Ingenium es solo para chicos?",
+        body:
+          "No. Acompañamos trayectorias escolares y formativas en distintos momentos (incluye ingresos y etapas exigentes).",
+      },
+      {
+        title: "¿Trabajan por materias?",
+        body:
+          "Trabajamos contenidos, sí, pero el eje es el proceso: método, comprensión, organización y autonomía.",
+      },
+      {
+        title: "¿Individual o grupal?",
+        body:
+          "Depende de la necesidad. Si es grupal, siempre es reducido (primaria 3, secundaria 4).",
+      },
+      {
+        title: "¿Cómo manejan previas e ingresos?",
+        body:
+          "Como momentos críticos: acompañamiento intensivo + planificación + manejo del estrés.",
+      },
+      {
+        title: "¿La familia participa?",
+        body:
+          "Sí: comunicación clara y acuerdos para sostener hábitos fuera del espacio.",
+      },
+      {
+        title: "¿Cómo se define la propuesta?",
+        body: "En la entrevista inicial, según la trayectoria y el momento.",
+      },
+    ],
+    variant: "faq",
+  },
+];


### PR DESCRIPTION
### Motivation
- Replace the current mixed copy/components with a single, typed source of truth for the landing copy and section structure to match the new content skeleton.
- Render the new sections dynamically to keep the existing visual components and styles while enabling reordering and content updates from data.
- Provide a minimal sticky anchor navigation and smooth scrolling for quick access to key sections without changing visual design.
- Ensure the FAQ is present and the existing contact/ubicación block remains unchanged and reachable via `#contacto`.

### Description
- Added a typed content file with all section copy and nav metadata at `data/ingeniumSections.ts` and exported `ingeniumHero`, `ingeniumNav` and `ingeniumSections`.
- Implemented a reusable renderer `components/sections/IngeniumSectionRenderer.tsx` that maps section `variant`s (`cards`, `bullets`, `proposals`, `text`, `text-list`, `faq`) to existing UI patterns.
- Replaced the previous page composition with dynamic rendering in `app/page.tsx`, added `components/sections/StickyNav.tsx` and updated `components/sections/Hero.tsx` to use the new hero copy data.
- Enabled smooth anchor scrolling by adding `html { scroll-behavior: smooth; }` in `app/globals.css` and placed the FAQ before the existing contact block while leaving contact text/links intact.

### Testing
- Started the dev server with `npm run dev` and received a successful server start and HTTP `GET /` with `200` status, indicating the page renders in dev mode.
- Ran a Playwright script that visited `http://127.0.0.1:3000` and successfully produced a full-page screenshot at `artifacts/ingenium-home.png`.
- The dev run emitted warnings about downloading Google Fonts (fallback fonts were used), but these were non-fatal and the page still rendered correctly.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590843f0dc832d80ccf99a8f867dd7)