### PR TITLE
Update landing sections, navigation, and FAQ

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -81,6 +81,10 @@
   --sidebar-ring: oklch(0.709 0.01 56.259);
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 .dark {
   --background: oklch(0.147 0.004 49.25);
   --foreground: oklch(0.985 0.001 106.423);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,16 @@
 import { FloralDecor, PaperBackground } from "@/components/FloralDecor";
-import Audience from "@/components/sections/Audience";
-import Conditions from "@/components/sections/Conditions";
-import ContactCTA from "@/components/sections/ContactCTA";
 import FloralSeparator from "@/components/sections/FloralSeparator";
+import ContactCTA from "@/components/sections/ContactCTA";
+import FamiliesSection from "@/components/sections/FamiliesSection";
+import FaqSection from "@/components/sections/FaqSection";
+import GroupsSection from "@/components/sections/GroupsSection";
 import Hero from "@/components/sections/Hero";
-import HowWeWork from "@/components/sections/HowWeWork";
+import InterviewSection from "@/components/sections/InterviewSection";
+import PedagogicSection from "@/components/sections/PedagogicSection";
+import ProposalsSection from "@/components/sections/ProposalsSection";
+import StickyNav from "@/components/sections/StickyNav";
+import SupportSection from "@/components/sections/SupportSection";
+import TechnologySection from "@/components/sections/TechnologySection";
 
 export default function Home() {
   return (
@@ -14,15 +20,35 @@ export default function Home() {
           <FloralDecor variant="leftTop" />
           <Hero />
         </PaperBackground>
+        <StickyNav />
         <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="leftMid" />
-          <HowWeWork />
+          <SupportSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <Audience />
+          <PedagogicSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <FloralDecor variant="rightTop" />
+          <ProposalsSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <GroupsSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <FamiliesSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <FloralDecor variant="rightBottom" />
+          <TechnologySection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <InterviewSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <FaqSection />
         </PaperBackground>
         <FloralSeparator />
-        <Conditions />
         <ContactCTA />
       </main>
     </div>

--- a/components/sections/FamiliesSection.tsx
+++ b/components/sections/FamiliesSection.tsx
@@ -1,0 +1,26 @@
+import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import Section from "@/components/ui/Section";
+
+export default function FamiliesSection() {
+  const section = ingeniumSectionsById["familias-escuelas"];
+
+  return (
+    <Section id={section.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-4">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {section.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {section.body}
+          </p>
+          {section.subtitle ? (
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {section.subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/FaqSection.tsx
+++ b/components/sections/FaqSection.tsx
@@ -1,0 +1,35 @@
+import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import Section from "@/components/ui/Section";
+
+export default function FaqSection() {
+  const section = ingeniumSectionsById["faq"];
+
+  return (
+    <Section id={section.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-8">
+          <div className="text-center">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {section.title}
+            </h2>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            {section.items?.map((item) => (
+              <div
+                key={item.title}
+                className="flex h-full flex-col gap-3 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
+              >
+                <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                  {item.title}
+                </h3>
+                <p className="text-sm leading-relaxed text-[#6a5743]">
+                  {item.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/GroupsSection.tsx
+++ b/components/sections/GroupsSection.tsx
@@ -1,0 +1,34 @@
+import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import Section from "@/components/ui/Section";
+
+export default function GroupsSection() {
+  const section = ingeniumSectionsById["grupos-reducidos"];
+
+  return (
+    <Section id={section.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-6">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {section.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {section.body}
+          </p>
+          <ul className="space-y-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {section.items?.map((item) => (
+              <li key={item.title} className="flex gap-3">
+                <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                <span>{item.title}</span>
+              </li>
+            ))}
+          </ul>
+          {section.subtitle ? (
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {section.subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,10 +1,11 @@
-import { ingeniumCopy } from "@/content/ingenium.copy";
+import { ingeniumSections } from "@/data/ingeniumSections";
 import Section from "@/components/ui/Section";
 import { ingeniumMedia } from "@/content/ingenium.media";
 import Image from "next/image";
 
 export default function Hero() {
-  const { brand, hero } = ingeniumCopy;
+  const { hero } = ingeniumSections;
+  const primaryCta = hero.ctas[0];
 
   return (
     <Section className="pt-16 sm:pt-24">
@@ -13,30 +14,24 @@ export default function Hero() {
           <div className="space-y-6">
             <div className="space-y-3">
               <h1 className="text-3xl font-semibold uppercase tracking-[0.25em] text-[#B88A3B] sm:text-4xl lg:text-5xl">
-                {brand.name}
+                {hero.title}
               </h1>
               <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl lg:text-4xl">
-                {hero.title}
+                {hero.subtitle}
               </h2>
               <p className="text-base leading-relaxed text-[#5c4a36] sm:text-lg">
-                {hero.subtitle}
+                {hero.body}
               </p>
             </div>
             <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
-              {brand.intro}
+              {hero.microtext}
             </p>
             <div className="flex flex-col gap-3 sm:flex-row">
               <a
-                href={hero.ctaPrimary.href}
+                href={primaryCta.href}
                 className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/25 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
               >
-                {hero.ctaPrimary.label}
-              </a>
-              <a
-                href={hero.ctaSecondary.href}
-                className="inline-flex w-full items-center justify-center rounded-full border border-[#d9c3a1] bg-white/80 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] sm:w-auto sm:text-base"
-              >
-                {hero.ctaSecondary.label}
+                {primaryCta.label}
               </a>
             </div>
           </div>

--- a/components/sections/InterviewSection.tsx
+++ b/components/sections/InterviewSection.tsx
@@ -1,0 +1,38 @@
+import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import Section from "@/components/ui/Section";
+
+export default function InterviewSection() {
+  const section = ingeniumSectionsById["entrevista"];
+  const cta = section.ctas?.[0];
+
+  return (
+    <Section id={section.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-6">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {section.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {section.body}
+          </p>
+          <ul className="grid gap-3 text-sm leading-relaxed text-[#6a5743] sm:grid-cols-2 sm:text-base">
+            {section.items?.map((item) => (
+              <li key={item.title} className="flex gap-3">
+                <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
+                <span>{item.title}</span>
+              </li>
+            ))}
+          </ul>
+          {cta ? (
+            <a
+              href={cta.href}
+              className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/20 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+            >
+              {cta.label}
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/PedagogicSection.tsx
+++ b/components/sections/PedagogicSection.tsx
@@ -1,0 +1,34 @@
+import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import Section from "@/components/ui/Section";
+
+export default function PedagogicSection() {
+  const section = ingeniumSectionsById["enfoque"];
+
+  return (
+    <Section id={section.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-8">
+          <div className="space-y-4">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {section.title}
+            </h2>
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {section.body}
+            </p>
+          </div>
+          <ul className="grid gap-4 sm:grid-cols-2">
+            {section.items?.map((item) => (
+              <li
+                key={item.title}
+                className="flex gap-3 rounded-[2rem] border border-[#eadfce] bg-white/90 p-4 text-sm leading-relaxed text-[#6a5743] shadow-[0_12px_28px_rgba(157,121,68,0.1)]"
+              >
+                <span className="mt-2 h-2 w-2 shrink-0 rounded-full bg-[#B88A3B]" />
+                <span>{item.title}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/ProposalsSection.tsx
+++ b/components/sections/ProposalsSection.tsx
@@ -1,0 +1,63 @@
+import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import Section from "@/components/ui/Section";
+
+export default function ProposalsSection() {
+  const section = ingeniumSectionsById["propuestas"];
+
+  return (
+    <Section id={section.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-10">
+          <div className="space-y-4 text-center">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {section.title}
+            </h2>
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {section.body}
+            </p>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-3">
+            {section.items?.map((item) => (
+              <div
+                key={item.title}
+                className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
+              >
+                <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                  {item.title}
+                </h3>
+                <div className="space-y-3 text-sm leading-relaxed text-[#6a5743]">
+                  {item.meta?.map((metaItem) => (
+                    <p key={metaItem.label}>
+                      <span className="font-semibold text-[#4a3725]">
+                        {metaItem.label}:
+                      </span>{" "}
+                      {metaItem.value}
+                    </p>
+                  ))}
+                  {item.list ? (
+                    <div className="space-y-2">
+                      {item.listLabel ? (
+                        <p className="font-semibold text-[#4a3725]">
+                          {item.listLabel}
+                        </p>
+                      ) : null}
+                      <ul className="space-y-2">
+                        {item.list.map((entry) => (
+                          <li key={entry} className="flex gap-3">
+                            <span className="mt-2 h-2 w-2 shrink-0 rounded-full bg-[#B88A3B]" />
+                            <span>{entry}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                  {item.body ? <p>{item.body}</p> : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/StickyNav.tsx
+++ b/components/sections/StickyNav.tsx
@@ -1,0 +1,26 @@
+import { ingeniumSections } from "@/data/ingeniumSections";
+
+export default function StickyNav() {
+  const navItems = ingeniumSections.sections.filter(
+    (section) => section.navLabel,
+  );
+
+  return (
+    <div className="sticky top-0 z-30 border-b border-[#eadfce] bg-white/85 backdrop-blur">
+      <nav
+        aria-label="Secciones principales"
+        className="mx-auto flex w-full max-w-6xl flex-wrap items-center gap-2 px-6 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#6b4d25] sm:gap-4 sm:text-sm"
+      >
+        {navItems.map((item) => (
+          <a
+            key={item.id}
+            href={`#${item.id}`}
+            className="rounded-full px-2 py-1 transition hover:text-[#B88A3B] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#B88A3B]"
+          >
+            {item.navLabel}
+          </a>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/components/sections/SupportSection.tsx
+++ b/components/sections/SupportSection.tsx
@@ -1,0 +1,57 @@
+import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import { FloralIcon } from "@/components/FloralDecor";
+import Section from "@/components/ui/Section";
+
+export default function SupportSection() {
+  const section = ingeniumSectionsById["como-acompana"];
+  const iconByIndex = ["flor", "flores", "corazon", "flor"] as const;
+  const cta = section.ctas?.[0];
+
+  return (
+    <Section id={section.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-10">
+          <div className="space-y-4 text-center">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+              {section.title}
+            </h2>
+            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+              {section.body}
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            {section.items?.map((item, index) => (
+              <div
+                key={item.title}
+                className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
+              >
+                <FloralIcon
+                  icon={iconByIndex[index % iconByIndex.length]}
+                  className={index % 2 === 1 ? "bg-[#f5e2c7]" : undefined}
+                />
+                <div className="space-y-3">
+                  <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                    {item.title}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                    {item.body}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+          {cta ? (
+            <div className="flex justify-center">
+              <a
+                href={cta.href}
+                className="inline-flex items-center justify-center rounded-full border border-[#d9c3a1] bg-white/85 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] sm:text-base"
+              >
+                {cta.label}
+              </a>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/components/sections/TechnologySection.tsx
+++ b/components/sections/TechnologySection.tsx
@@ -1,0 +1,21 @@
+import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import Section from "@/components/ui/Section";
+
+export default function TechnologySection() {
+  const section = ingeniumSectionsById["tecnologia"];
+
+  return (
+    <Section id={section.id}>
+      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+        <div className="space-y-4">
+          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            {section.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            {section.body}
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/data/ingeniumSections.ts
+++ b/data/ingeniumSections.ts
@@ -1,0 +1,252 @@
+import { ingeniumContact } from "@/lib/contact";
+
+type SectionCta = {
+  label: string;
+  href: string;
+  variant?: "primary" | "secondary";
+};
+
+type SectionMeta = {
+  label: string;
+  value: string;
+};
+
+type SectionItem = {
+  title: string;
+  body?: string;
+  meta?: SectionMeta[];
+  list?: string[];
+  listLabel?: string;
+};
+
+export type IngeniumSection = {
+  id: string;
+  navLabel: string;
+  title: string;
+  subtitle?: string;
+  body: string | string[];
+  items?: SectionItem[];
+  ctas?: SectionCta[];
+};
+
+const hero = {
+  title: "INGENIUM",
+  subtitle: "Acompañamiento educativo",
+  body:
+    "Un espacio para aprender a organizarse por dentro: hábitos de estudio, comprensión, autonomía y calma en los momentos que más pesan.",
+  microtext:
+    "No es solo apoyo escolar: acompañamos trayectorias, con criterio pedagógico y seguimiento cercano.",
+  ctas: [
+    {
+      label: "Consultar por WhatsApp",
+      href: ingeniumContact.whatsappUrl,
+      variant: "primary",
+    },
+  ],
+} as const;
+
+const sections = [
+  {
+    id: "como-acompana",
+    navLabel: "Cómo acompaña",
+    title: "Cómo acompaña Ingenium",
+    body:
+      "Cada proceso necesita un tipo de acompañamiento. Estas son las situaciones más comunes con las que llegan familias, estudiantes y también escuelas.",
+    items: [
+      {
+        title: "Sostener el estudio",
+        body:
+          "Cuando hay esfuerzo, pero los resultados no aparecen. Trabajamos comprensión, método y constancia, sin correr atrás de la tarea.",
+      },
+      {
+        title: "Organización y planificación",
+        body:
+          "Cuando todo se hace a último momento y estudiar se vuelve caos. Ordenamos rutinas, prioridades y herramientas para que el estudio sea manejable.",
+      },
+      {
+        title: "Instancias exigentes",
+        body:
+          "Previas, ingresos, exámenes, cambios de ritmo. Acompañamiento intensivo con organización del estudio y manejo del estrés académico.",
+      },
+      {
+        title: "Trayectorias en transición",
+        body:
+          "Cambios de nivel, repitencia, desmotivación, bloqueos. Reconstruimos el proceso paso a paso, con acuerdos claros y acompañamiento real.",
+      },
+    ],
+    ctas: [
+      {
+        label: "Contanos tu situación y te decimos cuál es el mejor camino.",
+        href: ingeniumContact.whatsappUrl,
+        variant: "secondary",
+      },
+    ],
+  },
+  {
+    id: "enfoque",
+    navLabel: "",
+    title: "Enfoque pedagógico",
+    body:
+      "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
+    items: [
+      { title: "Hábitos de estudio sostenidos" },
+      { title: "Organización y jerarquización de actividades" },
+      { title: "Comprensión e interpretación (no memorización vacía)" },
+      { title: "Manejo del estrés y cuidado del clima emocional" },
+      { title: "Tecnología como herramienta (con criterio, no uso pasivo)" },
+      { title: "Articulación alumno–familia–escuela" },
+    ],
+  },
+  {
+    id: "propuestas",
+    navLabel: "Propuestas",
+    title: "Propuestas",
+    body:
+      "No vendemos ‘paquetes’. Definimos la propuesta en una entrevista inicial según la necesidad real.",
+    items: [
+      {
+        title: "Acompañamiento sostenido (Apoyo escolar)",
+        meta: [
+          { label: "Para quién", value: "Primaria y secundaria." },
+          { label: "Modalidades", value: "Individual o grupal." },
+          {
+            label: "Enfoque",
+            value: "Contenidos escolares + hábitos + organización + comprensión.",
+          },
+        ],
+      },
+      {
+        title: "Momentos de exigencia (previas e ingresos)",
+        listLabel: "Incluye:",
+        list: [
+          "Preparación de materias pendientes (febrero / marzo)",
+          "Ingresos a colegios con examen",
+          "Preparación preuniversitaria",
+        ],
+        body:
+          "Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
+      },
+      {
+        title: "Cursos y talleres (duración acotada, enfoque práctico)",
+        listLabel: "Ejemplos:",
+        list: [
+          "Técnicas de estudio",
+          "Organización y planificación",
+          "Comprensión lectora",
+          "Razonamiento matemático",
+          "Acompañamiento en momentos críticos",
+        ],
+        body: "Grupos reducidos, contenidos focalizados y práctica guiada.",
+      },
+    ],
+  },
+  {
+    id: "grupos-reducidos",
+    navLabel: "Grupos reducidos",
+    title: "Grupos reducidos",
+    body:
+      "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
+    subtitle:
+      "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
+    items: [
+      { title: "Primaria: hasta 3 estudiantes" },
+      { title: "Secundaria: hasta 4 estudiantes" },
+    ],
+  },
+  {
+    id: "familias-escuelas",
+    navLabel: "Familias y escuelas",
+    title: "Familias y escuelas",
+    body:
+      "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
+    subtitle:
+      "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
+  },
+  {
+    id: "tecnologia",
+    navLabel: "",
+    title: "Tecnología con criterio",
+    body:
+      "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
+  },
+  {
+    id: "entrevista",
+    navLabel: "",
+    title: "Entrevista inicial",
+    body:
+      "Para cuidar el proceso, primero escuchamos la situación y definimos un camino posible: modalidad, frecuencia, objetivos y acuerdos.",
+    items: [
+      { title: "Etapa escolar/formativa" },
+      { title: "Organización actual y hábitos" },
+      { title: "Nivel de comprensión / método" },
+      { title: "Estrés y contexto" },
+      { title: "Uso de tecnología" },
+      { title: "Expectativas de la familia" },
+    ],
+    ctas: [
+      {
+        label: "Consultar por WhatsApp",
+        href: ingeniumContact.whatsappUrl,
+        variant: "primary",
+      },
+    ],
+  },
+  {
+    id: "faq",
+    navLabel: "",
+    title: "FAQ",
+    body: "",
+    items: [
+      {
+        title: "¿Ingenium es solo para chicos?",
+        body:
+          "No. Acompañamos trayectorias escolares y formativas en distintos momentos (incluye ingresos y etapas exigentes).",
+      },
+      {
+        title: "¿Trabajan por materias?",
+        body:
+          "Trabajamos contenidos, sí, pero el eje es el proceso: método, comprensión, organización y autonomía.",
+      },
+      {
+        title: "¿Individual o grupal?",
+        body:
+          "Depende de la necesidad. Si es grupal, siempre es reducido (primaria 3, secundaria 4).",
+      },
+      {
+        title: "¿Cómo manejan previas e ingresos?",
+        body:
+          "Como momentos críticos: acompañamiento intensivo + planificación + manejo del estrés.",
+      },
+      {
+        title: "¿La familia participa?",
+        body:
+          "Sí: comunicación clara y acuerdos para sostener hábitos fuera del espacio.",
+      },
+      {
+        title: "¿Cómo se define la propuesta?",
+        body: "En la entrevista inicial, según la trayectoria y el momento.",
+      },
+    ],
+  },
+  {
+    id: "contacto",
+    navLabel: "Contacto",
+    title: "Contacto",
+    body: "",
+  },
+] satisfies IngeniumSection[];
+
+export const ingeniumSections = {
+  hero,
+  sections,
+} as const;
+
+export type IngeniumSectionId = (typeof sections)[number]["id"];
+
+export const ingeniumSectionsById = sections.reduce(
+  (accumulator, section) => {
+    accumulator[section.id] = section;
+    return accumulator;
+  },
+  {} as Record<IngeniumSectionId, IngeniumSection>,
+);


### PR DESCRIPTION
### Motivation
- Centralize and standardize landing copy and structure into a single typed content source to match the new section skeleton and copy requirements.
- Render the site sections from data to allow content-first updates and to align headings/order with the provided documentation.
- Provide a minimal sticky anchor navigation to improve discoverability of the main sections without changing visual branding.
- Insert a simple FAQ block before the contact block while explicitly keeping the existing contact/ubicación content untouched.

### Description
- Add a typed content source at `data/ingeniumSections.ts` that contains `hero` and a `sections` array with ids, `navLabel`, titles, bodies, items and CTAs.
- Replace the original landing render with a content-driven layout by updating `app/page.tsx` and adding new section components (`SupportSection`, `PedagogicSection`, `ProposalsSection`, `GroupsSection`, `FamiliesSection`, `TechnologySection`, `InterviewSection`, `FaqSection`) that consume the new data.
- Update `Hero` to use the new `ingeniumSections` data, add a sticky anchor navigation component `StickyNav`, and enable smooth scrolling by adding `scroll-behavior: smooth` to `app/globals.css`.
- Preserve and reuse the existing contact/location block (`ContactCTA` with `id="contacto"`) and the existing phone/Google Maps values pulled from `lib/contact` so no location/contact copy was modified.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and confirmed the site compiled and served the landing page (GET / returned 200), although Google Fonts downloads failed in this environment and fallback fonts were used.
- Ran a headless Playwright script to visit `http://127.0.0.1:3000` and capture a full-page screenshot which completed successfully (`artifacts/ingenium-home.png`).
- Verified TypeScript/Next compilation in the dev session with no runtime errors related to the new components in this environment.
- No automated unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590843f0dc832d80ccf99a8f867dd7)