### PR TITLE
Reorder Ingenium homepage sections: Apoyo escolar first; add Exámenes y previas

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { FloralDecor, PaperBackground } from "@/components/FloralDecor";
 import FloralSeparator from "@/components/sections/FloralSeparator";
 import ContactCTA from "@/components/sections/ContactCTA";
+import ExamsSection from "@/components/sections/ExamsSection";
 import FamiliesSection from "@/components/sections/FamiliesSection";
 import FaqSection from "@/components/sections/FaqSection";
 import GroupsSection from "@/components/sections/GroupsSection";
@@ -22,28 +23,31 @@ export default function Home() {
         </PaperBackground>
         <StickyNav />
         <PaperBackground variant="section" allowOverflow>
-          <FloralDecor variant="leftMid" />
-          <SupportSection />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
-          <PedagogicSection />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="rightTop" />
           <ProposalsSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <GroupsSection />
+          <ExamsSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <FamiliesSection />
+          <FloralDecor variant="leftMid" />
+          <SupportSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <InterviewSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <PedagogicSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="rightBottom" />
           <TechnologySection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <InterviewSection />
+          <GroupsSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <FamiliesSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
           <FaqSection />

--- a/components/sections/ExamsSection.tsx
+++ b/components/sections/ExamsSection.tsx
@@ -1,8 +1,8 @@
 import { ingeniumSectionsById } from "@/data/ingeniumSections";
 import Section from "@/components/ui/Section";
 
-export default function ProposalsSection() {
-  const section = ingeniumSectionsById["apoyo-escolar"];
+export default function ExamsSection() {
+  const section = ingeniumSectionsById["examenes-previas"];
 
   return (
     <Section id={section.id}>

--- a/data/ingeniumSections.ts
+++ b/data/ingeniumSections.ts
@@ -47,6 +47,58 @@ const hero = {
 
 const sections = [
   {
+    id: "apoyo-escolar",
+    navLabel: "Apoyo escolar",
+    title: "Apoyo escolar",
+    body:
+      "Apoyo escolar para primaria, secundaria y etapa preuniversitaria, con acompañamiento preventivo y sostenido en hábitos, organización, comprensión y autonomía. Definimos la propuesta en una entrevista inicial según la necesidad real.",
+    items: [
+      {
+        title: "Acompañamiento sostenido (Apoyo escolar)",
+        meta: [
+          { label: "Para quién", value: "Primaria y secundaria." },
+          { label: "Modalidades", value: "Individual o grupal." },
+          {
+            label: "Enfoque",
+            value: "Contenidos escolares + hábitos + organización + comprensión.",
+          },
+        ],
+      },
+      {
+        title: "Cursos y talleres (duración acotada, enfoque práctico)",
+        listLabel: "Ejemplos:",
+        list: [
+          "Técnicas de estudio",
+          "Organización y planificación",
+          "Comprensión lectora",
+          "Razonamiento matemático",
+          "Acompañamiento en momentos críticos",
+        ],
+        body: "Grupos reducidos, contenidos focalizados y práctica guiada.",
+      },
+    ],
+  },
+  {
+    id: "examenes-previas",
+    navLabel: "Exámenes y previas",
+    title: "Exámenes y previas",
+    body:
+      "Primero aparecen los exámenes y, cuando una materia no se sostiene, llegan las previas: exámenes de materias adeudadas. En ambos casos hay acompañamiento intensivo, con planificación y manejo del estrés.",
+    items: [
+      {
+        title: "Exámenes y previas",
+        listLabel: "Incluye:",
+        list: [
+          "Preparación de materias pendientes (febrero / marzo)",
+          "Ingresos a colegios con examen",
+          "Preparación preuniversitaria",
+        ],
+        body:
+          "Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
+      },
+    ],
+  },
+  {
     id: "como-acompana",
     navLabel: "Cómo acompaña",
     title: "Cómo acompaña Ingenium",
@@ -83,93 +135,6 @@ const sections = [
     ],
   },
   {
-    id: "enfoque",
-    navLabel: "",
-    title: "Enfoque pedagógico",
-    body:
-      "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
-    items: [
-      { title: "Hábitos de estudio sostenidos" },
-      { title: "Organización y jerarquización de actividades" },
-      { title: "Comprensión e interpretación (no memorización vacía)" },
-      { title: "Manejo del estrés y cuidado del clima emocional" },
-      { title: "Tecnología como herramienta (con criterio, no uso pasivo)" },
-      { title: "Articulación alumno–familia–escuela" },
-    ],
-  },
-  {
-    id: "propuestas",
-    navLabel: "Propuestas",
-    title: "Propuestas",
-    body:
-      "No vendemos ‘paquetes’. Definimos la propuesta en una entrevista inicial según la necesidad real.",
-    items: [
-      {
-        title: "Acompañamiento sostenido (Apoyo escolar)",
-        meta: [
-          { label: "Para quién", value: "Primaria y secundaria." },
-          { label: "Modalidades", value: "Individual o grupal." },
-          {
-            label: "Enfoque",
-            value: "Contenidos escolares + hábitos + organización + comprensión.",
-          },
-        ],
-      },
-      {
-        title: "Momentos de exigencia (previas e ingresos)",
-        listLabel: "Incluye:",
-        list: [
-          "Preparación de materias pendientes (febrero / marzo)",
-          "Ingresos a colegios con examen",
-          "Preparación preuniversitaria",
-        ],
-        body:
-          "Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
-      },
-      {
-        title: "Cursos y talleres (duración acotada, enfoque práctico)",
-        listLabel: "Ejemplos:",
-        list: [
-          "Técnicas de estudio",
-          "Organización y planificación",
-          "Comprensión lectora",
-          "Razonamiento matemático",
-          "Acompañamiento en momentos críticos",
-        ],
-        body: "Grupos reducidos, contenidos focalizados y práctica guiada.",
-      },
-    ],
-  },
-  {
-    id: "grupos-reducidos",
-    navLabel: "Grupos reducidos",
-    title: "Grupos reducidos",
-    body:
-      "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
-    subtitle:
-      "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
-    items: [
-      { title: "Primaria: hasta 3 estudiantes" },
-      { title: "Secundaria: hasta 4 estudiantes" },
-    ],
-  },
-  {
-    id: "familias-escuelas",
-    navLabel: "Familias y escuelas",
-    title: "Familias y escuelas",
-    body:
-      "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
-    subtitle:
-      "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
-  },
-  {
-    id: "tecnologia",
-    navLabel: "",
-    title: "Tecnología con criterio",
-    body:
-      "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
-  },
-  {
     id: "entrevista",
     navLabel: "",
     title: "Entrevista inicial",
@@ -192,9 +157,53 @@ const sections = [
     ],
   },
   {
+    id: "enfoque",
+    navLabel: "",
+    title: "Enfoque pedagógico",
+    body:
+      "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
+    items: [
+      { title: "Hábitos de estudio sostenidos" },
+      { title: "Organización y jerarquización de actividades" },
+      { title: "Comprensión e interpretación (no memorización vacía)" },
+      { title: "Manejo del estrés y cuidado del clima emocional" },
+      { title: "Tecnología como herramienta (con criterio, no uso pasivo)" },
+      { title: "Articulación alumno–familia–escuela" },
+    ],
+  },
+  {
+    id: "tecnologia",
+    navLabel: "",
+    title: "Tecnología con criterio",
+    body:
+      "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
+  },
+  {
+    id: "grupos-reducidos",
+    navLabel: "",
+    title: "Grupos reducidos",
+    body:
+      "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
+    subtitle:
+      "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
+    items: [
+      { title: "Primaria: hasta 3 estudiantes" },
+      { title: "Secundaria: hasta 4 estudiantes" },
+    ],
+  },
+  {
+    id: "familias-escuelas",
+    navLabel: "",
+    title: "Familias y escuelas",
+    body:
+      "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
+    subtitle:
+      "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
+  },
+  {
     id: "faq",
     navLabel: "",
-    title: "FAQ",
+    title: "Antes de empezar",
     body: "",
     items: [
       {


### PR DESCRIPTION
### Motivation
- Reorganizar la secuencia de secciones para que el acompañamiento preventivo aparezca primero y el correctivo después, sin cambiar estilos ni lógica de renderizado. 
- Separar la subsección de momentos de exigencia en una sección independiente para dejar claro el flujo: exámenes primero, previas cuando una materia no se sostiene. 
- Mantener todos los contenidos existentes y ajustar solo títulos, orden y los primeros párrafos indicados.

### Description
- Reworked `data/ingeniumSections.ts`: created `apoyo-escolar` (renombrado/recubierto desde la antigua sección de "Propuestas") y `examenes-previas`, ajustando los `navLabel`, `title` y los primeros párrafos según el requerimiento, y renombrando `FAQ` a `Antes de empezar` (`title`).
- Added a new `components/sections/ExamsSection.tsx` that renders the `examenes-previas` section and updated `components/sections/ProposalsSection.tsx` to read `apoyo-escolar` instead of the old key. 
- Reordered the homepage in `app/page.tsx` to place `Apoyo escolar` first, then `Exámenes y previas`, followed by the existing sequence (`Cómo acompaña`, `Entrevista inicial`, `Enfoque pedagógico`, `Tecnología con criterio`, `Familias y escuelas`, `Antes de empezar`, `Contacto`) without adding or removing sections. 
- Kept existing components, layout and styling intact; the sticky navigation continues to derive entries from `navLabel` values so it now surfaces `Apoyo escolar`, `Exámenes y previas`, `Cómo acompaña` and `Contacto` as required.

### Testing
- La aplicación se inició en modo desarrollo con `npm run dev -- --hostname 0.0.0.0 --port 3000` y la página principal respondió `GET / 200` verificando que la reordenación no rompió el render básico. 
- Se capturó una captura de pantalla automatizada con Playwright para validar visualmente el nuevo orden (artefacto generado durante la prueba). 
- Durante el arranque aparecieron advertencias de descarga de fuentes de Google (`next/font`), que no bloquearon el servidor y se aplicaron fuentes fallback correctamente. 
- No se ejecutaron suites de tests unitarios/CI porque los cambios son de contenido y layout; las comprobaciones se limitaron a iniciar el servidor y revisar el render.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1f274990832d9b00a6189ac128bc)