### PR TITLE
Reordenar secciones: `Apoyo escolar` primero y `Exámenes y previas` como sección propia

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,28 +22,31 @@ export default function Home() {
         </PaperBackground>
         <StickyNav />
         <PaperBackground variant="section" allowOverflow>
+          <FloralDecor variant="rightTop" />
+          <ProposalsSection sectionId="apoyo-escolar" />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <ProposalsSection sectionId="examenes-previas" />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="leftMid" />
           <SupportSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
+          <InterviewSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
           <PedagogicSection />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
-          <FloralDecor variant="rightTop" />
-          <ProposalsSection />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
-          <GroupsSection />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
-          <FamiliesSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="rightBottom" />
           <TechnologySection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <InterviewSection />
+          <FamiliesSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <GroupsSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
           <FaqSection />

--- a/components/sections/ProposalsSection.tsx
+++ b/components/sections/ProposalsSection.tsx
@@ -1,8 +1,17 @@
-import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import {
+  ingeniumSectionsById,
+  type IngeniumSectionId,
+} from "@/data/ingeniumSections";
 import Section from "@/components/ui/Section";
 
-export default function ProposalsSection() {
-  const section = ingeniumSectionsById["propuestas"];
+type ProposalsSectionProps = {
+  sectionId: IngeniumSectionId;
+};
+
+export default function ProposalsSection({
+  sectionId,
+}: ProposalsSectionProps) {
+  const section = ingeniumSectionsById[sectionId];
 
   return (
     <Section id={section.id}>

--- a/data/ingeniumSections.ts
+++ b/data/ingeniumSections.ts
@@ -47,6 +47,58 @@ const hero = {
 
 const sections = [
   {
+    id: "apoyo-escolar",
+    navLabel: "Apoyo escolar",
+    title: "Apoyo escolar",
+    body:
+      "El apoyo escolar incluye primaria, secundaria y etapa preuniversitaria, con un acompañamiento preventivo y sostenido (hábitos, organización, comprensión y autonomía). No vendemos ‘paquetes’. Definimos la propuesta en una entrevista inicial según la necesidad real.",
+    items: [
+      {
+        title: "Acompañamiento sostenido (Apoyo escolar)",
+        meta: [
+          { label: "Para quién", value: "Primaria y secundaria." },
+          { label: "Modalidades", value: "Individual o grupal." },
+          {
+            label: "Enfoque",
+            value: "Contenidos escolares + hábitos + organización + comprensión.",
+          },
+        ],
+      },
+      {
+        title: "Cursos y talleres (duración acotada, enfoque práctico)",
+        listLabel: "Ejemplos:",
+        list: [
+          "Técnicas de estudio",
+          "Organización y planificación",
+          "Comprensión lectora",
+          "Razonamiento matemático",
+          "Acompañamiento en momentos críticos",
+        ],
+        body: "Grupos reducidos, contenidos focalizados y práctica guiada.",
+      },
+    ],
+  },
+  {
+    id: "examenes-previas",
+    navLabel: "Exámenes y previas",
+    title: "Exámenes y previas",
+    body:
+      "Primero aparecen los exámenes y, cuando una materia no se sostiene, las previas, entendidas también como exámenes de materias adeudadas. En ambos casos, el acompañamiento es intensivo, con metodología, planificación y manejo del estrés.",
+    items: [
+      {
+        title: "Exámenes y previas",
+        listLabel: "Incluye:",
+        list: [
+          "Preparación de materias pendientes (febrero / marzo)",
+          "Ingresos a colegios con examen",
+          "Preparación preuniversitaria",
+        ],
+        body:
+          "Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
+      },
+    ],
+  },
+  {
     id: "como-acompana",
     navLabel: "Cómo acompaña",
     title: "Cómo acompaña Ingenium",
@@ -83,93 +135,6 @@ const sections = [
     ],
   },
   {
-    id: "enfoque",
-    navLabel: "",
-    title: "Enfoque pedagógico",
-    body:
-      "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
-    items: [
-      { title: "Hábitos de estudio sostenidos" },
-      { title: "Organización y jerarquización de actividades" },
-      { title: "Comprensión e interpretación (no memorización vacía)" },
-      { title: "Manejo del estrés y cuidado del clima emocional" },
-      { title: "Tecnología como herramienta (con criterio, no uso pasivo)" },
-      { title: "Articulación alumno–familia–escuela" },
-    ],
-  },
-  {
-    id: "propuestas",
-    navLabel: "Propuestas",
-    title: "Propuestas",
-    body:
-      "No vendemos ‘paquetes’. Definimos la propuesta en una entrevista inicial según la necesidad real.",
-    items: [
-      {
-        title: "Acompañamiento sostenido (Apoyo escolar)",
-        meta: [
-          { label: "Para quién", value: "Primaria y secundaria." },
-          { label: "Modalidades", value: "Individual o grupal." },
-          {
-            label: "Enfoque",
-            value: "Contenidos escolares + hábitos + organización + comprensión.",
-          },
-        ],
-      },
-      {
-        title: "Momentos de exigencia (previas e ingresos)",
-        listLabel: "Incluye:",
-        list: [
-          "Preparación de materias pendientes (febrero / marzo)",
-          "Ingresos a colegios con examen",
-          "Preparación preuniversitaria",
-        ],
-        body:
-          "Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
-      },
-      {
-        title: "Cursos y talleres (duración acotada, enfoque práctico)",
-        listLabel: "Ejemplos:",
-        list: [
-          "Técnicas de estudio",
-          "Organización y planificación",
-          "Comprensión lectora",
-          "Razonamiento matemático",
-          "Acompañamiento en momentos críticos",
-        ],
-        body: "Grupos reducidos, contenidos focalizados y práctica guiada.",
-      },
-    ],
-  },
-  {
-    id: "grupos-reducidos",
-    navLabel: "Grupos reducidos",
-    title: "Grupos reducidos",
-    body:
-      "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
-    subtitle:
-      "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
-    items: [
-      { title: "Primaria: hasta 3 estudiantes" },
-      { title: "Secundaria: hasta 4 estudiantes" },
-    ],
-  },
-  {
-    id: "familias-escuelas",
-    navLabel: "Familias y escuelas",
-    title: "Familias y escuelas",
-    body:
-      "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
-    subtitle:
-      "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
-  },
-  {
-    id: "tecnologia",
-    navLabel: "",
-    title: "Tecnología con criterio",
-    body:
-      "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
-  },
-  {
     id: "entrevista",
     navLabel: "",
     title: "Entrevista inicial",
@@ -192,9 +157,53 @@ const sections = [
     ],
   },
   {
+    id: "enfoque",
+    navLabel: "",
+    title: "Enfoque pedagógico",
+    body:
+      "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
+    items: [
+      { title: "Hábitos de estudio sostenidos" },
+      { title: "Organización y jerarquización de actividades" },
+      { title: "Comprensión e interpretación (no memorización vacía)" },
+      { title: "Manejo del estrés y cuidado del clima emocional" },
+      { title: "Tecnología como herramienta (con criterio, no uso pasivo)" },
+      { title: "Articulación alumno–familia–escuela" },
+    ],
+  },
+  {
+    id: "tecnologia",
+    navLabel: "",
+    title: "Tecnología con criterio",
+    body:
+      "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
+  },
+  {
+    id: "grupos-reducidos",
+    navLabel: "",
+    title: "Grupos reducidos",
+    body:
+      "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
+    subtitle:
+      "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
+    items: [
+      { title: "Primaria: hasta 3 estudiantes" },
+      { title: "Secundaria: hasta 4 estudiantes" },
+    ],
+  },
+  {
+    id: "familias-escuelas",
+    navLabel: "",
+    title: "Familias y escuelas",
+    body:
+      "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
+    subtitle:
+      "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
+  },
+  {
     id: "faq",
     navLabel: "",
-    title: "FAQ",
+    title: "Antes de empezar",
     body: "",
     items: [
       {


### PR DESCRIPTION
### Motivation
- Reordenar la estructura de la página para priorizar el acompañamiento preventivo antes del correctivo, manteniendo la sección `Hero` intacta.
- Separar la subsección de “Momentos de exigencia” en una sección independiente llamada `Exámenes y previas` y renombrar `Propuestas` a `Apoyo escolar` con un texto introductorio ajustado.
- Actualizar las etiquetas de navegación (navLabel) y anclas para que el menú sticky refleje la nueva estructura.
- Mantener el resto de secciones, estilos y lógica de renderizado sin cambios conceptuales.

### Description
- Actualicé `data/ingeniumSections.ts` para crear `apoyo-escolar` y `examenes-previas`, ajustar títulos, `navLabel` y los primeros párrafos, y renombré la sección `faq` a `Antes de empezar`.
- Cambié `components/sections/ProposalsSection.tsx` para aceptar un prop `sectionId: IngeniumSectionId` y renderizar la sección indicada desde `ingeniumSectionsById`.
- Reordené `app/page.tsx` para mostrar `Apoyo escolar` primero (`<ProposalsSection sectionId="apoyo-escolar" />`), luego `Exámenes y previas` (`<ProposalsSection sectionId="examenes-previas" />`) y el resto de secciones en el orden requerido.
- No se modificaron estilos, componentes visuales ni la lógica de renderizado de las secciones que no lo requerían, y `StickyNav` sigue leyendo `navLabel` desde los datos para construir el menú.

### Testing
- Levanté el servidor de desarrollo con `npm run dev` y la página respondió `GET / 200`, aunque la descarga de fuentes de Google falló (advertencias) y se usaron fuentes de fallback; el servidor arrancó correctamente.
- Generé una captura de la página con un script de Playwright y la ejecución completó correctamente creando `artifacts/ingenium-home.png`.
- No se ejecutaron tests unitarios adicionales porque los cambios son de contenido y estructura de secciones.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1f274990832d9b00a6189ac128bc)