### PR TITLE
Reorder homepage sections and rename "Propuestas" → "Apoyo escolar"

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { FloralDecor, PaperBackground } from "@/components/FloralDecor";
 import FloralSeparator from "@/components/sections/FloralSeparator";
 import ContactCTA from "@/components/sections/ContactCTA";
+import ExamsSection from "@/components/sections/ExamsSection";
 import FamiliesSection from "@/components/sections/FamiliesSection";
 import FaqSection from "@/components/sections/FaqSection";
 import GroupsSection from "@/components/sections/GroupsSection";
@@ -23,27 +24,30 @@ export default function Home() {
         <StickyNav />
         <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="leftMid" />
-          <SupportSection />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
-          <PedagogicSection />
-        </PaperBackground>
-        <PaperBackground variant="section" allowOverflow>
-          <FloralDecor variant="rightTop" />
           <ProposalsSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <GroupsSection />
+          <FloralDecor variant="rightTop" />
+          <ExamsSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <FamiliesSection />
+          <SupportSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <InterviewSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <PedagogicSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
           <FloralDecor variant="rightBottom" />
           <TechnologySection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
-          <InterviewSection />
+          <FamiliesSection />
+        </PaperBackground>
+        <PaperBackground variant="section" allowOverflow>
+          <GroupsSection />
         </PaperBackground>
         <PaperBackground variant="section" allowOverflow>
           <FaqSection />

--- a/components/sections/ExamsSection.tsx
+++ b/components/sections/ExamsSection.tsx
@@ -1,8 +1,8 @@
 import { ingeniumSectionsById } from "@/data/ingeniumSections";
 import Section from "@/components/ui/Section";
 
-export default function ProposalsSection() {
-  const section = ingeniumSectionsById["apoyo-escolar"];
+export default function ExamsSection() {
+  const section = ingeniumSectionsById["examenes-previas"];
 
   return (
     <Section id={section.id}>
@@ -16,7 +16,7 @@ export default function ProposalsSection() {
               {section.body}
             </p>
           </div>
-          <div className="grid gap-6 lg:grid-cols-3">
+          <div className="grid gap-6 lg:grid-cols-1">
             {section.items?.map((item) => (
               <div
                 key={item.title}
@@ -26,14 +26,6 @@ export default function ProposalsSection() {
                   {item.title}
                 </h3>
                 <div className="space-y-3 text-sm leading-relaxed text-[#6a5743]">
-                  {item.meta?.map((metaItem) => (
-                    <p key={metaItem.label}>
-                      <span className="font-semibold text-[#4a3725]">
-                        {metaItem.label}:
-                      </span>{" "}
-                      {metaItem.value}
-                    </p>
-                  ))}
                   {item.list ? (
                     <div className="space-y-2">
                       {item.listLabel ? (

--- a/data/ingeniumSections.ts
+++ b/data/ingeniumSections.ts
@@ -47,6 +47,55 @@ const hero = {
 
 const sections = [
   {
+    id: "apoyo-escolar",
+    navLabel: "Apoyo escolar",
+    title: "Apoyo escolar",
+    body:
+      "Acompañamiento preventivo y sostenido para primaria, secundaria y etapa preuniversitaria: hábitos, organización, comprensión y autonomía. No vendemos ‘paquetes’. Definimos la propuesta en una entrevista inicial según la necesidad real.",
+    items: [
+      {
+        title: "Acompañamiento sostenido (Apoyo escolar)",
+        meta: [
+          { label: "Para quién", value: "Primaria y secundaria." },
+          { label: "Modalidades", value: "Individual o grupal." },
+          {
+            label: "Enfoque",
+            value: "Contenidos escolares + hábitos + organización + comprensión.",
+          },
+        ],
+      },
+      {
+        title: "Cursos y talleres (duración acotada, enfoque práctico)",
+        listLabel: "Ejemplos:",
+        list: [
+          "Técnicas de estudio",
+          "Organización y planificación",
+          "Comprensión lectora",
+          "Razonamiento matemático",
+          "Acompañamiento en momentos críticos",
+        ],
+        body: "Grupos reducidos, contenidos focalizados y práctica guiada.",
+      },
+    ],
+  },
+  {
+    id: "examenes-previas",
+    navLabel: "Exámenes y previas",
+    title: "Exámenes y previas",
+    body:
+      "Primero aparecen los exámenes y, cuando una materia no se sostiene, las previas, entendidas también como exámenes de materias adeudadas. Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
+    items: [
+      {
+        title: "Incluye",
+        list: [
+          "Preparación de materias pendientes (febrero / marzo)",
+          "Ingresos a colegios con examen",
+          "Preparación preuniversitaria",
+        ],
+      },
+    ],
+  },
+  {
     id: "como-acompana",
     navLabel: "Cómo acompaña",
     title: "Cómo acompaña Ingenium",
@@ -83,93 +132,6 @@ const sections = [
     ],
   },
   {
-    id: "enfoque",
-    navLabel: "",
-    title: "Enfoque pedagógico",
-    body:
-      "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
-    items: [
-      { title: "Hábitos de estudio sostenidos" },
-      { title: "Organización y jerarquización de actividades" },
-      { title: "Comprensión e interpretación (no memorización vacía)" },
-      { title: "Manejo del estrés y cuidado del clima emocional" },
-      { title: "Tecnología como herramienta (con criterio, no uso pasivo)" },
-      { title: "Articulación alumno–familia–escuela" },
-    ],
-  },
-  {
-    id: "propuestas",
-    navLabel: "Propuestas",
-    title: "Propuestas",
-    body:
-      "No vendemos ‘paquetes’. Definimos la propuesta en una entrevista inicial según la necesidad real.",
-    items: [
-      {
-        title: "Acompañamiento sostenido (Apoyo escolar)",
-        meta: [
-          { label: "Para quién", value: "Primaria y secundaria." },
-          { label: "Modalidades", value: "Individual o grupal." },
-          {
-            label: "Enfoque",
-            value: "Contenidos escolares + hábitos + organización + comprensión.",
-          },
-        ],
-      },
-      {
-        title: "Momentos de exigencia (previas e ingresos)",
-        listLabel: "Incluye:",
-        list: [
-          "Preparación de materias pendientes (febrero / marzo)",
-          "Ingresos a colegios con examen",
-          "Preparación preuniversitaria",
-        ],
-        body:
-          "Acompañamiento intensivo, metodología, planificación y manejo del estrés.",
-      },
-      {
-        title: "Cursos y talleres (duración acotada, enfoque práctico)",
-        listLabel: "Ejemplos:",
-        list: [
-          "Técnicas de estudio",
-          "Organización y planificación",
-          "Comprensión lectora",
-          "Razonamiento matemático",
-          "Acompañamiento en momentos críticos",
-        ],
-        body: "Grupos reducidos, contenidos focalizados y práctica guiada.",
-      },
-    ],
-  },
-  {
-    id: "grupos-reducidos",
-    navLabel: "Grupos reducidos",
-    title: "Grupos reducidos",
-    body:
-      "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
-    subtitle:
-      "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
-    items: [
-      { title: "Primaria: hasta 3 estudiantes" },
-      { title: "Secundaria: hasta 4 estudiantes" },
-    ],
-  },
-  {
-    id: "familias-escuelas",
-    navLabel: "Familias y escuelas",
-    title: "Familias y escuelas",
-    body:
-      "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
-    subtitle:
-      "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
-  },
-  {
-    id: "tecnologia",
-    navLabel: "",
-    title: "Tecnología con criterio",
-    body:
-      "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
-  },
-  {
     id: "entrevista",
     navLabel: "",
     title: "Entrevista inicial",
@@ -192,9 +154,53 @@ const sections = [
     ],
   },
   {
+    id: "enfoque",
+    navLabel: "",
+    title: "Enfoque pedagógico",
+    body:
+      "En Ingenium entendemos que aprender hoy combina dimensiones académicas, metodológicas, emocionales y tecnológicas. Por eso acompañamos el proceso completo, no solo el contenido del día.",
+    items: [
+      { title: "Hábitos de estudio sostenidos" },
+      { title: "Organización y jerarquización de actividades" },
+      { title: "Comprensión e interpretación (no memorización vacía)" },
+      { title: "Manejo del estrés y cuidado del clima emocional" },
+      { title: "Tecnología como herramienta (con criterio, no uso pasivo)" },
+      { title: "Articulación alumno–familia–escuela" },
+    ],
+  },
+  {
+    id: "tecnologia",
+    navLabel: "",
+    title: "Tecnología con criterio",
+    body:
+      "En Ingenium la tecnología no reemplaza el acompañamiento: se integra de manera consciente para organizar el estudio, acceder a contenidos y mejorar la comprensión, evitando el uso pasivo o desordenado.",
+  },
+  {
+    id: "familias-escuelas",
+    navLabel: "",
+    title: "Familias y escuelas",
+    body:
+      "La familia forma parte del proceso. Trabajamos con comunicación clara, acuerdos y seguimiento para sostener hábitos y organización también fuera de Ingenium.",
+    subtitle:
+      "También articulamos con la escuela cuando hace falta, respetando criterios, tiempos y exigencias.",
+  },
+  {
+    id: "grupos-reducidos",
+    navLabel: "",
+    title: "Grupos reducidos",
+    body:
+      "Ingenium trabaja con grupos reducidos como decisión pedagógica, no como estrategia comercial.",
+    subtitle:
+      "Esto permite seguimiento cercano, respeto por ritmos individuales y procesos más sostenidos.",
+    items: [
+      { title: "Primaria: hasta 3 estudiantes" },
+      { title: "Secundaria: hasta 4 estudiantes" },
+    ],
+  },
+  {
     id: "faq",
     navLabel: "",
-    title: "FAQ",
+    title: "Antes de empezar",
     body: "",
     items: [
       {


### PR DESCRIPTION
### Motivation
- Prioritize preventive accompaniment by making the current “Propuestas” section the first content section and renaming it to “Apoyo escolar”.
- Separate the corrective/urgent offering into its own section named “Exámenes y previas” so navigation reflects preventive → corrective flow.
- Keep the visual styles, components and rendering logic unchanged while only adjusting titles, order and the requested first-paragraph copy.
- Update the sticky menu anchors to match the new primary navigation labels for clarity.

### Description
- Reworked `data/ingeniumSections.ts`: added `apoyo-escolar` and `examenes-previas` entries, moved and reordered sections, and changed the FAQ `title` to `Antes de empezar` while adjusting the requested first-paragraph copy for the two renamed sections.
- Updated `components/sections/ProposalsSection.tsx` to load the new `apoyo-escolar` section and added a new `components/sections/ExamsSection.tsx` to render `examenes-previas` as a standalone section.
- Reordered the homepage flow in `app/page.tsx` to place `Apoyo escolar` first, followed by `Exámenes y previas`, then the remaining sections in the requested order without altering component internals.
- Left component structure and styles intact and ensured the sticky nav continues to read `navLabel` values from the sections data (so the menu now surfaces `Apoyo escolar`, `Exámenes y previas`, `Cómo acompaña`, `Contacto`).

### Testing
- Started the dev server with `npm run dev` and the homepage compiled and responded with a `200` HTTP status when requested. 
- Captured a full-page screenshot via an automated Playwright script saved at `artifacts/ingenium-home.png` to verify layout and ordering visually. 
- The Next.js compilation emitted Google Fonts download warnings but fell back to local fonts and the page rendered successfully. 
- No unit or integration test suites were executed as part of these content and layout changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1f274990832d9b00a6189ac128bc)