### PR TITLE
Add Instagram link (SVG) to root layout footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,6 +78,22 @@ export default function RootLayout({
           }}
         />
         {children}
+        <footer className="flex justify-center pb-6 pt-4">
+          <a
+            href="https://www.instagram.com/ingenium_barbaratomba?igsh=ZDhzMWhuNTdzMWp3"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram de Ingenium"
+            className="inline-flex items-center justify-center"
+          >
+            <img
+              src="/media/ingenium/icons/instagram.svg"
+              alt="Instagram"
+              width="20"
+              height="20"
+            />
+          </a>
+        </footer>
       </body>
     </html>
   );


### PR DESCRIPTION
### Motivation

- The site should provide a link to the project's Instagram account using the existing SVG icon without changing layout, text, or overall design.  
- The project uses the App Router (`app/layout.tsx` exists), so the root layout is the appropriate place to add a minimal footer.  
- Keep styling minimal and consistent with existing footer/link patterns.  

### Description

- Added a small footer to `app/layout.tsx` that centers an Instagram link using the existing icon at `/media/ingenium/icons/instagram.svg`.  
- The link opens in a new tab and includes accessibility attributes: `target="_blank" rel="noopener noreferrer" aria-label="Instagram de Ingenium"`.  
- The icon is used via an `<img>` with `src="/media/ingenium/icons/instagram.svg" alt="Instagram" width="20" height="20"` and minimal Tailwind classes (`flex justify-center pb-6 pt-4`, `inline-flex items-center justify-center`).  
- No other files, layout ordering, texts or visual design were modified.  

### Testing

- Started the dev server with `next dev` and loaded the homepage successfully (`GET / 200`) and captured a screenshot confirming the footer rendered.  
- Ran the automated linter with `npm run lint`, which completed with 2 warnings and no errors (unused `eslint-disable` for `react/no-danger` and `@next/next/no-img-element` warning for using `<img>`).  
- No TypeScript errors were reported during the dev server run, though Google Fonts failed to download in the environment and Next.js fell back to system fonts (warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eddc81284832d9c944718c0e10801)