### PR TITLE
Use og-image.png for Open Graph preview with explicit dimensions and type

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,8 +31,11 @@ export const metadata: Metadata = {
     type: "website",
     images: [
       {
-        url: "/media/ingenium/illustrations/flores-corazon.png",
+        url: "https://ingenium-web.vercel.app/og-image.png",
         alt: "Ingenium — Apoyo educativo",
+        width: 1200,
+        height: 630,
+        type: "image/png",
       },
     ],
   },


### PR DESCRIPTION
### Motivation

- Ensure the site uses the existing `/public/og-image.png` as the Open Graph preview image with an absolute URL.
- Provide explicit image metadata so social platforms can generate correct large previews with known dimensions and MIME type.
- Keep all other metadata, layout, and visible content unchanged as required.
- Avoid moving or renaming the existing image file while improving preview integration.

### Description

- Updated `app/layout.tsx` to set `openGraph.images[0].url` to `https://ingenium-web.vercel.app/og-image.png`.
- Added `width: 1200`, `height: 630`, and `type: "image/png"` to the Open Graph image object.
- Left existing metadata (title, description, `twitter` settings, and other fields) unchanged.
- Modified file: `app/layout.tsx`.

### Testing

- No automated tests were executed for this change.
- Linting or type-check runs were not performed as part of this update.
- Manual verification steps (not automated) are recommended to confirm social preview behavior.
- No test failures to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee9c5c37c832da38c36cc4dac8349)