### PR TITLE
Use HTTP-date in security.txt

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:pablosiklosi@gmail.com
+Expires: Wed, 31 Dec 2026 23:59:59 GMT
+Policy: https://ingenium-web.vercel.app


### PR DESCRIPTION
### Motivation

- Provide a canonical `security.txt` for the static site containing a standard security contact.
- Ensure the `Expires` field follows the RFC 9116 requirement by using the HTTP-date format.

### Description

- Add `public/.well-known/security.txt` containing the required `Contact`, `Expires`, and `Policy` lines.
- Update the `Expires` value to the RFC 9116 HTTP-date `Wed, 31 Dec 2026 23:59:59 GMT` and do not modify any other lines.

### Testing

- No automated tests were run for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f145a1d44832d901e207c87b147e1)