### PR TITLE
UI polish: buttons, cards, typography, focus states

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,3 +175,38 @@ html {
     mix-blend-mode: multiply;
   }
 }
+
+
+@layer components {
+  .section-shell {
+    @apply rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14;
+  }
+
+  .section-heading {
+    @apply text-2xl font-semibold tracking-tight text-[#3f2f20];
+  }
+
+  .section-subheading {
+    @apply text-xl font-semibold text-[#4a3725];
+  }
+
+  .section-body {
+    @apply text-base leading-relaxed text-[#6a5743];
+  }
+
+  .section-secondary {
+    @apply text-sm leading-relaxed text-[#6a5743];
+  }
+}
+
+
+@layer base {
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible,
+  [role="button"]:focus-visible {
+    @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
+  }
+}

--- a/components/sections/Audience.tsx
+++ b/components/sections/Audience.tsx
@@ -14,10 +14,10 @@ export default function Audience() {
 
   return (
     <Section id="para-quien">
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-10">
           <div className="text-center">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            <h2 className="section-heading sm:text-3xl">
               {audience.title}
             </h2>
           </div>
@@ -37,10 +37,10 @@ export default function Audience() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                  <h3 className="section-subheading">
                     {item.title}
                   </h3>
-                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                  <p className="section-secondary">
                     {item.body}
                   </p>
                 </div>

--- a/components/sections/Conditions.tsx
+++ b/components/sections/Conditions.tsx
@@ -6,15 +6,15 @@ export default function Conditions() {
 
   return (
     <Section id="condiciones">
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-6">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+          <h2 className="section-heading sm:text-3xl">
             {conditions.title}
           </h2>
-          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+          <p className="section-body">
             {conditions.preface}
           </p>
-          <ul className="space-y-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
+          <ul className="space-y-3 section-body">
             {conditions.bullets.map((bullet) => (
               <li key={bullet} className="flex gap-3">
                 <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -1,5 +1,7 @@
 import { ingeniumCopy } from "@/content/ingenium.copy";
 import { ingeniumContact } from "@/lib/contact";
+import { Card } from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button";
 import Section from "@/components/ui/Section";
 
 export default function ContactCTA() {
@@ -13,26 +15,20 @@ export default function ContactCTA() {
             <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[#B88A3B]">
               {brand.name}
             </p>
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
-              {brand.tagline}
-            </h2>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            <h2 className="section-heading sm:text-3xl">{brand.tagline}</h2>
+            <p className="section-body">
               Coordinemos una entrevista para conocer la situación de cada
               estudiante y proponer un plan de acompañamiento a medida.
             </p>
           </div>
-          <div className="space-y-4 rounded-[2.25rem] border border-[#eadfce] bg-white/85 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]">
-            <p className="text-sm font-semibold text-[#4a3725]">
-              Contacto
-            </p>
-            <p className="text-sm leading-relaxed text-[#6a5743]">
+          <Card className="space-y-4 text-left">
+            <p className="text-sm font-semibold text-[#4a3725]">Contacto</p>
+            <p className="section-secondary">
               Dejanos tu consulta y nos pondremos en contacto para coordinar
               disponibilidad, modalidad y objetivos de acompañamiento.
             </p>
             <div className="space-y-1 text-sm text-[#6a5743]">
-              <p>
-                📍 {ingeniumContact.addressLine}
-              </p>
+              <p>📍 {ingeniumContact.addressLine}</p>
               <a
                 href={ingeniumContact.googleMapsUrl}
                 target="_blank"
@@ -45,11 +41,11 @@ export default function ContactCTA() {
             </div>
             <a
               href={hero.ctaPrimary.href}
-              className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/20 transition hover:translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+              className={buttonVariants({ variant: "primary", fullWidth: true })}
             >
               {hero.ctaPrimary.label}
             </a>
-          </div>
+          </Card>
         </div>
       </div>
     </Section>

--- a/components/sections/ExamsSection.tsx
+++ b/components/sections/ExamsSection.tsx
@@ -1,4 +1,5 @@
 import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import { Card } from "@/components/ui/card";
 import Section from "@/components/ui/Section";
 
 export default function ExamsSection() {
@@ -6,32 +7,21 @@ export default function ExamsSection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-10">
           <div className="space-y-4 text-center">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
-              {section.title}
-            </h2>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
-              {section.body}
-            </p>
+            <h2 className="section-heading sm:text-3xl">{section.title}</h2>
+            <p className="section-body">{section.body}</p>
           </div>
           <div className="grid gap-6 lg:grid-cols-1">
             {section.items?.map((item) => (
-              <div
-                key={item.title}
-                className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
-              >
-                <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
-                  {item.title}
-                </h3>
-                <div className="space-y-3 text-sm leading-relaxed text-[#6a5743]">
+              <Card key={item.title} className="flex h-full flex-col gap-4 text-left">
+                <h3 className="section-subheading">{item.title}</h3>
+                <div className="space-y-3 section-secondary">
                   {item.list ? (
                     <div className="space-y-2">
                       {item.listLabel ? (
-                        <p className="font-semibold text-[#4a3725]">
-                          {item.listLabel}
-                        </p>
+                        <p className="font-semibold text-[#4a3725]">{item.listLabel}</p>
                       ) : null}
                       <ul className="space-y-2">
                         {item.list.map((entry) => (
@@ -45,7 +35,7 @@ export default function ExamsSection() {
                   ) : null}
                   {item.body ? <p>{item.body}</p> : null}
                 </div>
-              </div>
+              </Card>
             ))}
           </div>
         </div>

--- a/components/sections/FamiliesSection.tsx
+++ b/components/sections/FamiliesSection.tsx
@@ -6,16 +6,16 @@ export default function FamiliesSection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-4">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+          <h2 className="section-heading sm:text-3xl">
             {section.title}
           </h2>
-          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+          <p className="section-body">
             {section.body}
           </p>
           {section.subtitle ? (
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            <p className="section-body">
               {section.subtitle}
             </p>
           ) : null}

--- a/components/sections/FaqSection.tsx
+++ b/components/sections/FaqSection.tsx
@@ -1,4 +1,5 @@
 import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import { Card } from "@/components/ui/card";
 import Section from "@/components/ui/Section";
 
 export default function FaqSection() {
@@ -6,26 +7,17 @@ export default function FaqSection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-8">
           <div className="text-center">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
-              {section.title}
-            </h2>
+            <h2 className="section-heading sm:text-3xl">{section.title}</h2>
           </div>
           <div className="grid gap-6 md:grid-cols-2">
             {section.items?.map((item) => (
-              <div
-                key={item.title}
-                className="flex h-full flex-col gap-3 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
-              >
-                <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
-                  {item.title}
-                </h3>
-                <p className="text-sm leading-relaxed text-[#6a5743]">
-                  {item.body}
-                </p>
-              </div>
+              <Card key={item.title} className="flex h-full flex-col gap-3 text-left">
+                <h3 className="section-subheading">{item.title}</h3>
+                <p className="section-secondary">{item.body}</p>
+              </Card>
             ))}
           </div>
         </div>

--- a/components/sections/GroupsSection.tsx
+++ b/components/sections/GroupsSection.tsx
@@ -6,15 +6,15 @@ export default function GroupsSection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-6">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+          <h2 className="section-heading sm:text-3xl">
             {section.title}
           </h2>
-          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+          <p className="section-body">
             {section.body}
           </p>
-          <ul className="space-y-3 text-sm leading-relaxed text-[#6a5743] sm:text-base">
+          <ul className="space-y-3 section-body">
             {section.items?.map((item) => (
               <li key={item.title} className="flex gap-3">
                 <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
@@ -23,7 +23,7 @@ export default function GroupsSection() {
             ))}
           </ul>
           {section.subtitle ? (
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            <p className="section-body">
               {section.subtitle}
             </p>
           ) : null}

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,6 +1,7 @@
 import { ingeniumSections } from "@/data/ingeniumSections";
 import Section from "@/components/ui/Section";
 import { ingeniumMedia } from "@/content/ingenium.media";
+import { buttonVariants } from "@/components/ui/button";
 import Image from "next/image";
 
 export default function Hero() {
@@ -16,20 +17,18 @@ export default function Hero() {
               <h1 className="text-3xl font-semibold uppercase tracking-[0.25em] text-[#B88A3B] sm:text-4xl lg:text-5xl">
                 {hero.title}
               </h1>
-              <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl lg:text-4xl">
+              <h2 className="section-heading sm:text-3xl lg:text-4xl">
                 {hero.subtitle}
               </h2>
               <p className="text-base leading-relaxed text-[#5c4a36] sm:text-lg">
                 {hero.body}
               </p>
             </div>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
-              {hero.microtext}
-            </p>
+            <p className="section-body">{hero.microtext}</p>
             <div className="flex flex-col gap-3 sm:flex-row">
               <a
                 href={primaryCta.href}
-                className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/25 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+                className={buttonVariants({ variant: "primary", fullWidth: true })}
               >
                 {primaryCta.label}
               </a>

--- a/components/sections/HowWeWork.tsx
+++ b/components/sections/HowWeWork.tsx
@@ -8,10 +8,10 @@ export default function HowWeWork() {
 
   return (
     <Section id="como-trabajamos">
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-10">
           <div className="text-center">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            <h2 className="section-heading sm:text-3xl">
               {howWeWork.title}
             </h2>
           </div>
@@ -26,10 +26,10 @@ export default function HowWeWork() {
                   className={index === 1 ? "bg-[#f5e2c7]" : undefined}
                 />
                 <div className="space-y-3">
-                  <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                  <h3 className="section-subheading">
                     {item.title}
                   </h3>
-                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                  <p className="section-secondary">
                     {item.body}
                   </p>
                 </div>

--- a/components/sections/InterviewSection.tsx
+++ b/components/sections/InterviewSection.tsx
@@ -1,4 +1,5 @@
 import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import { buttonVariants } from "@/components/ui/button";
 import Section from "@/components/ui/Section";
 
 export default function InterviewSection() {
@@ -7,15 +8,11 @@ export default function InterviewSection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-6">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
-            {section.title}
-          </h2>
-          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
-            {section.body}
-          </p>
-          <ul className="grid gap-3 text-sm leading-relaxed text-[#6a5743] sm:grid-cols-2 sm:text-base">
+          <h2 className="section-heading sm:text-3xl">{section.title}</h2>
+          <p className="section-body">{section.body}</p>
+          <ul className="grid gap-3 section-body sm:grid-cols-2">
             {section.items?.map((item) => (
               <li key={item.title} className="flex gap-3">
                 <span className="mt-2 h-2 w-2 rounded-full bg-[#B88A3B]" />
@@ -26,7 +23,7 @@ export default function InterviewSection() {
           {cta ? (
             <a
               href={cta.href}
-              className="inline-flex w-full items-center justify-center rounded-full bg-[#B88A3B] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#B88A3B]/20 transition hover:-translate-y-0.5 hover:bg-[#a97c33] sm:w-auto sm:text-base"
+              className={buttonVariants({ variant: "primary", fullWidth: true })}
             >
               {cta.label}
             </a>

--- a/components/sections/PedagogicSection.tsx
+++ b/components/sections/PedagogicSection.tsx
@@ -6,13 +6,13 @@ export default function PedagogicSection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-8">
           <div className="space-y-4">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            <h2 className="section-heading sm:text-3xl">
               {section.title}
             </h2>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            <p className="section-body">
               {section.body}
             </p>
           </div>
@@ -20,7 +20,7 @@ export default function PedagogicSection() {
             {section.items?.map((item) => (
               <li
                 key={item.title}
-                className="flex gap-3 rounded-[2rem] border border-[#eadfce] bg-white/90 p-4 text-sm leading-relaxed text-[#6a5743] shadow-[0_12px_28px_rgba(157,121,68,0.1)]"
+                className="flex gap-3 rounded-[2rem] border border-[#eadfce] bg-white/90 p-4 section-secondary shadow-[0_12px_28px_rgba(157,121,68,0.1)]"
               >
                 <span className="mt-2 h-2 w-2 shrink-0 rounded-full bg-[#B88A3B]" />
                 <span>{item.title}</span>

--- a/components/sections/ProposalsSection.tsx
+++ b/components/sections/ProposalsSection.tsx
@@ -1,4 +1,5 @@
 import { ingeniumSectionsById } from "@/data/ingeniumSections";
+import { Card } from "@/components/ui/card";
 import Section from "@/components/ui/Section";
 
 export default function ProposalsSection() {
@@ -6,26 +7,17 @@ export default function ProposalsSection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-10">
           <div className="space-y-4 text-center">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
-              {section.title}
-            </h2>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
-              {section.body}
-            </p>
+            <h2 className="section-heading sm:text-3xl">{section.title}</h2>
+            <p className="section-body">{section.body}</p>
           </div>
           <div className="grid gap-6 lg:grid-cols-3">
             {section.items?.map((item) => (
-              <div
-                key={item.title}
-                className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
-              >
-                <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
-                  {item.title}
-                </h3>
-                <div className="space-y-3 text-sm leading-relaxed text-[#6a5743]">
+              <Card key={item.title} className="flex h-full flex-col gap-4 text-left">
+                <h3 className="section-subheading">{item.title}</h3>
+                <div className="space-y-3 section-secondary">
                   {item.meta?.map((metaItem) => (
                     <p key={metaItem.label}>
                       <span className="font-semibold text-[#4a3725]">
@@ -37,9 +29,7 @@ export default function ProposalsSection() {
                   {item.list ? (
                     <div className="space-y-2">
                       {item.listLabel ? (
-                        <p className="font-semibold text-[#4a3725]">
-                          {item.listLabel}
-                        </p>
+                        <p className="font-semibold text-[#4a3725]">{item.listLabel}</p>
                       ) : null}
                       <ul className="space-y-2">
                         {item.list.map((entry) => (
@@ -53,7 +43,7 @@ export default function ProposalsSection() {
                   ) : null}
                   {item.body ? <p>{item.body}</p> : null}
                 </div>
-              </div>
+              </Card>
             ))}
           </div>
         </div>

--- a/components/sections/StickyNav.tsx
+++ b/components/sections/StickyNav.tsx
@@ -15,7 +15,7 @@ export default function StickyNav() {
           <a
             key={item.id}
             href={`#${item.id}`}
-            className="rounded-full px-2 py-1 transition hover:text-[#B88A3B] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#B88A3B]"
+            className="rounded-full px-2 py-1 transition hover:text-[#B88A3B]"
           >
             {item.navLabel}
           </a>

--- a/components/sections/SupportSection.tsx
+++ b/components/sections/SupportSection.tsx
@@ -1,5 +1,7 @@
 import { ingeniumSectionsById } from "@/data/ingeniumSections";
 import { FloralIcon } from "@/components/FloralDecor";
+import { buttonVariants } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import Section from "@/components/ui/Section";
 
 export default function SupportSection() {
@@ -9,42 +11,39 @@ export default function SupportSection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-10">
           <div className="space-y-4 text-center">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+            <h2 className="section-heading sm:text-3xl">
               {section.title}
             </h2>
-            <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+            <p className="section-body">
               {section.body}
             </p>
           </div>
           <div className="grid gap-6 md:grid-cols-2">
             {section.items?.map((item, index) => (
-              <div
-                key={item.title}
-                className="flex h-full flex-col gap-4 rounded-[2.25rem] border border-[#eadfce] bg-white/90 p-6 text-left shadow-[0_14px_35px_rgba(157,121,68,0.12)]"
-              >
+              <Card key={item.title} className="flex h-full flex-col gap-4 text-left">
                 <FloralIcon
                   icon={iconByIndex[index % iconByIndex.length]}
                   className={index % 2 === 1 ? "bg-[#f5e2c7]" : undefined}
                 />
                 <div className="space-y-3">
-                  <h3 className="font-serif text-lg font-semibold text-[#4a3725]">
+                  <h3 className="section-subheading">
                     {item.title}
                   </h3>
-                  <p className="text-sm leading-relaxed text-[#6a5743]">
+                  <p className="section-secondary">
                     {item.body}
                   </p>
                 </div>
-              </div>
+              </Card>
             ))}
           </div>
           {cta ? (
             <div className="flex justify-center">
               <a
                 href={cta.href}
-                className="inline-flex items-center justify-center rounded-full border border-[#d9c3a1] bg-white/85 px-6 py-3 text-sm font-semibold text-[#6b4d25] shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfae7a] sm:text-base"
+                className={buttonVariants({ variant: "secondary" })}
               >
                 {cta.label}
               </a>

--- a/components/sections/TechnologySection.tsx
+++ b/components/sections/TechnologySection.tsx
@@ -6,12 +6,12 @@ export default function TechnologySection() {
 
   return (
     <Section id={section.id}>
-      <div className="rounded-[3rem] border border-[#eadfce] bg-white/85 p-8 shadow-[0_20px_55px_rgba(184,138,59,0.12)] backdrop-blur sm:p-12 lg:p-14">
+      <div className="section-shell">
         <div className="space-y-4">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-[#3f2f20] sm:text-3xl">
+          <h2 className="section-heading sm:text-3xl">
             {section.title}
           </h2>
-          <p className="text-sm leading-relaxed text-[#6a5743] sm:text-base">
+          <p className="section-body">
             {section.body}
           </p>
         </div>

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -12,7 +12,7 @@ export default function Section({ id, className, children }: SectionProps) {
   return (
     <section
       id={id}
-      className={cn("px-6 py-16 sm:py-24 lg:py-28", className)}
+      className={cn("px-6 py-12 sm:py-14 lg:py-16", className)}
     >
       <div className="mx-auto w-full max-w-6xl">{children}</div>
     </section>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-semibold transition-all duration-200 ease-out disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+  {
+    variants: {
+      variant: {
+        primary:
+          "bg-[#B88A3B] text-white shadow-md shadow-[#B88A3B]/25 hover:-translate-y-0.5 hover:shadow-lg hover:bg-[#a97c33] active:translate-y-0 active:shadow-sm",
+        secondary:
+          "border border-[#d9c3a1] bg-white/85 text-[#6b4d25] shadow-sm hover:-translate-y-0.5 hover:shadow-md hover:border-[#cfae7a] active:translate-y-0 active:shadow-sm",
+      },
+      size: {
+        default: "px-6 py-3 text-sm sm:text-base",
+        sm: "px-4 py-2 text-sm",
+      },
+      fullWidth: {
+        true: "w-full sm:w-auto",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "default",
+      fullWidth: false,
+    },
+  },
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  fullWidth,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? ("span" as const) : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, fullWidth, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,29 @@
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-[#eadfce]/90 bg-white/90 p-6 shadow-sm transition-shadow md:hover:shadow-md",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("space-y-2", className)} {...props} />;
+}
+
+export function CardContent({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("space-y-3", className)} {...props} />;
+}


### PR DESCRIPTION
### Motivation
- Improve the perceived "premium" feel on mobile by centralizing visual polish for buttons, cards, typographic hierarchy, vertical rhythm and focus states while leaving the hero layout and motion untouched.
- Keep changes minimal and centralized so the same tokens and palette are reused and no copy/order changes are made.

### Description
- Added a shared `Button` (`components/ui/button.tsx`) implementing `buttonVariants` with `transition-all duration-200 ease-out`, subtle lift on `:hover`, refined `:active` and accessible `:focus-visible` ring using existing theme tokens. 
- Added a shared `Card` (`components/ui/card.tsx`) with consistent `rounded-2xl` radius, subtle border and shadow, and `p-6` padding, and replaced repeated card markup in several sections to reuse this component. 
- Centralized section spacing and typography utilities in `app/globals.css` (`.section-shell`, `.section-heading`, `.section-subheading`, `.section-body`, `.section-secondary`) and reduced section vertical padding in `components/ui/Section.tsx` for a tighter, consistent vertical rhythm. 
- Updated multiple section files (e.g. `Hero`, `ProposalsSection`, `ExamsSection`, `FaqSection`, `SupportSection`, `ContactCTA`, etc.) to consume the new components/classes and switched CTA anchors to use the centralized button variants; the hero only received typographic/CTA class changes and no motion/layout/image changes.

### Testing
- Ran lint with `npm run lint` which completed and reported only pre-existing warnings unrelated to the changes. (success)
- Started the dev server with `npm run dev` and validated the mobile layout and interactions visually and captured a mobile screenshot for review. (success)
- Attempted production build with `npm run build` which failed in this environment due to inability to download Google Fonts (network fetch for `Geist`/`Geist Mono`), not because of the changes introduced. (build blocked by external network font fetch)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863d0fbfe4832da515dfb01350b5c9)