### PR TITLE
fix(hero): revert overlays/pills and restore previous typography

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,8 +6,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-body);
-  --font-mono: var(--font-ibm-mono);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -47,6 +47,8 @@
 }
 
 :root {
+  --font-geist-sans: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-geist-mono: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --radius: 0.85rem;
   --background: oklch(0.978 0.012 84.5);
   --foreground: oklch(0.312 0.023 57.8);
@@ -93,6 +95,9 @@
   --paper-glow: #fdf9f3;
   --paper-border: #dfcfba;
   --glass-border: rgba(255, 255, 255, 0.65);
+  --font-display: var(--font-geist-sans);
+  --font-body: var(--font-geist-sans);
+  --font-ibm-mono: var(--font-geist-mono);
 }
 
 html {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,23 +1,6 @@
 import type { Metadata } from "next";
-import { Fraunces, IBM_Plex_Mono, Manrope } from "next/font/google";
 import { ingeniumContact } from "@/lib/contact";
 import "./globals.css";
-
-const fraunces = Fraunces({
-  variable: "--font-display",
-  subsets: ["latin"],
-});
-
-const manrope = Manrope({
-  variable: "--font-body",
-  subsets: ["latin"],
-});
-
-const ibmPlexMono = IBM_Plex_Mono({
-  variable: "--font-ibm-mono",
-  weight: ["400", "500"],
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://ingenium-web.vercel.app"),
@@ -76,9 +59,7 @@ export default function RootLayout({
 
   return (
     <html lang="es">
-      <body
-        className={`${fraunces.variable} ${manrope.variable} ${ibmPlexMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -7,11 +7,6 @@ import Image from "next/image";
 export default function Hero() {
   const { hero } = ingeniumSections;
   const primaryCta = hero.ctas[0];
-  const highlights = [
-    "Seguimiento pedagógico cercano",
-    "Grupos reducidos con objetivos claros",
-    "Estrategias para estudiar con calma",
-  ];
 
   return (
     <Section className="pt-12 sm:pt-16 lg:pt-20">
@@ -22,7 +17,7 @@ export default function Hero() {
               <p className="inline-flex rounded-full border border-[#d8c2a6] bg-white/75 px-4 py-1.5 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[var(--brand-copper-deep)] shadow-[0_8px_18px_rgba(92,61,31,0.14)]">
                 Instituto de acompanamiento educativo
               </p>
-              <h1 className="font-display text-[clamp(2.8rem,2.2rem+2.1vw,4.9rem)] leading-[0.88] text-[var(--ink-950)]">
+              <h1 className="text-[clamp(2.8rem,2.2rem+2.1vw,4.9rem)] font-semibold leading-[0.88] tracking-[0.22em] uppercase text-[#B88A3B]">
                 {hero.title}
               </h1>
               <h2 className="section-heading max-w-2xl">
@@ -50,16 +45,8 @@ export default function Hero() {
               </a>
             </div>
           </div>
-          <div className="space-y-4">
+          <div>
             <div className="relative aspect-[4/3] overflow-hidden rounded-[2.55rem] border border-[#ddc9ae] bg-[#f5ebdd] shadow-[0_26px_44px_rgba(92,60,32,0.22)]">
-              <div className="absolute inset-x-5 top-5 z-20 flex items-center justify-between">
-                <p className="rounded-full border border-white/70 bg-white/75 px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-[var(--brand-sage)] backdrop-blur">
-                  Trayectorias sostenidas
-                </p>
-                <p className="rounded-full border border-white/70 bg-white/75 px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-[var(--brand-copper-deep)] backdrop-blur">
-                  Primaria - Secundaria - Preu
-                </p>
-              </div>
               <Image
                 src={ingeniumMedia.hero.main}
                 alt="Acompañamiento personalizado para estudiantes"
@@ -68,18 +55,7 @@ export default function Hero() {
                 className="object-cover"
                 sizes="(min-width: 1024px) 42vw, 100vw"
               />
-              <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_top,rgba(36,26,16,0.24),transparent_42%)]" />
             </div>
-            <ul className="grid gap-2 sm:grid-cols-3 lg:grid-cols-1">
-              {highlights.map((highlight) => (
-                <li
-                  key={highlight}
-                  className="rounded-[1.2rem] border border-[#d9c3a5] bg-white/72 px-4 py-3 text-sm leading-relaxed text-[var(--ink-700)] shadow-[0_10px_20px_rgba(92,60,32,0.11)]"
-                >
-                  {highlight}
-                </li>
-              ))}
-            </ul>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Revertir partes del rediseño que añadieron carteles/etiquetas sobre la imagen del hero, una lista de “píldoras” y una tipografía global diferente para devolver el logotipo/título y el layout a su aspecto previo sin introducir nuevos assets ni dependencias.
- Evitar la carga remota de fuentes que rompía el build en este entorno y mantener la configuración existente de Next.js + Tailwind + shadcn/ui.

### Description
- Eliminé los elementos visuales dibujados sobre la imagen del hero (badges superiores y capa de gradiente) y dejé el Image original sin overlays en `components/sections/Hero.tsx`.
- Eliminé la lista de `highlights` y el bloque de las “píldoras” del hero para que esa sección no se renderice ni ocupe espacio en `components/sections/Hero.tsx`.
- Revertí la carga de Google Fonts usada por la skill y quité las importaciones de `next/font` en `app/layout.tsx`, simplificando la clase del `<body>` para no depender de variables de font cargadas remotamente.
- Restablecí variables de fuente/fallback locales en `app/globals.css` para usar tipografías sans/mono de sistema y dejé el título principal (“INGENIUM”) con estilos sans/uppercase similares al estado previo; no modifiqué archivos de assets en `public`.
- Archivos modificados: `components/sections/Hero.tsx`, `app/layout.tsx`, `app/globals.css`.

### Testing
- Ejecuté `npm run build` y la compilación finalizó correctamente (`next build` completado sin errores`).
- Levanté el entorno de desarrollo con `npm run dev -- --hostname 0.0.0.0 --port 3000` y la ruta principal respondió correctamente (captura de pantalla generada para verificación visual).
- Comandos de verificación local recomendados: `npm install`, `npm run dev -- --hostname 0.0.0.0 --port 3000` y abrir `http://localhost:3000`, y para validar producción `npm run build` (ambos pasos se ejecutaron en CI/local y tuvieron éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fdcc62bc832d8284f0ceaff2e9f1)