### PR TITLE
Ajusta header y bloque de Contacto según referencia visual

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,14 +18,6 @@ export default function Home() {
   return (
     <div className="site-stage min-h-screen bg-paper text-[var(--ink-800)]">
       <main className="relative z-10">
-        <section className="px-5 pt-6 sm:px-7 sm:pt-8 lg:px-10">
-          <div className="mx-auto w-full max-w-[74rem]">
-            <div className="flex flex-wrap items-center justify-between gap-3 rounded-full border border-[#d9c3a6] bg-white/70 px-5 py-2.5 text-[0.62rem] font-semibold uppercase tracking-[0.16em] text-[var(--ink-600)] shadow-[0_10px_22px_rgba(91,60,30,0.14)]">
-              <p>Ingenium instituto educativo</p>
-              <p>Acompanamiento personalizado y sostenido</p>
-            </div>
-          </div>
-        </section>
         <PaperBackground variant="hero" allowOverflow>
           <FloralDecor variant="leftTop" />
           <Hero />

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -21,14 +21,6 @@ export default function ContactCTA() {
               cada estudiante y definir un plan de acompanamiento realista,
               claro y sostenido.
             </p>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="rounded-[1.2rem] border border-[#dcc7ac] bg-white/70 px-4 py-3 text-sm text-[var(--ink-700)] shadow-[0_9px_20px_rgba(84,56,28,0.11)]">
-                Modalidad individual o grupal segun necesidad.
-              </div>
-              <div className="rounded-[1.2rem] border border-[#dcc7ac] bg-white/70 px-4 py-3 text-sm text-[var(--ink-700)] shadow-[0_9px_20px_rgba(84,56,28,0.11)]">
-                Propuesta definida en base a objetivos y contexto.
-              </div>
-            </div>
           </div>
           <Card className="space-y-5 text-left">
             <p className="font-display text-[1.4rem] leading-none text-[var(--ink-900)]">
@@ -39,7 +31,7 @@ export default function ContactCTA() {
               disponibilidad, modalidad y objetivos de trabajo.
             </p>
             <div className="space-y-1 text-sm text-[var(--ink-700)]">
-              <p>{ingeniumContact.addressLine}</p>
+              <p>📍 {ingeniumContact.addressLine}</p>
               <a
                 href={ingeniumContact.googleMapsUrl}
                 target="_blank"


### PR DESCRIPTION
### Motivation
- Ajustar la interfaz para coincidir con las referencias visuales eliminando el encabezado superior tipo "pill" del home.
- Quitar los textos recuadrados en rojo de la segunda imagen que ya no deben mostrarse en la sección Contacto.
- Añadir un emoji de pin delante de la dirección en la tarjeta de Contacto según la tercera imagen.

### Description
- Eliminé el bloque superior tipo “pill” en la página principal en `app/page.tsx` para que la página comience directamente con el `Hero`.
- Eliminé los dos recuadros informativos en la columna izquierda de la sección de contacto en `components/sections/ContactCTA.tsx`.
- Agregué el emoji `📍` antes de la dirección reemplazando `<p>{ingeniumContact.addressLine}</p>` por `<p>📍 {ingeniumContact.addressLine}</p>` en `components/sections/ContactCTA.tsx`.
- Archivos modificados: `app/page.tsx` y `components/sections/ContactCTA.tsx`.

### Testing
- Ejecuté `npm run lint` y el linter pasó correctamente.
- Arranqué la app con `npm run dev` y el servidor respondió en `http://localhost:3000` sin errores.
- Generé una captura con Playwright (`artifacts/contacto-cambios.png`) para validar visualmente los cambios y la verificación visual fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69970cc89be8832d94c1de13ff17709d)