### PR TITLE
Refine heading hierarchy and simplify hero CTA

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -241,7 +241,7 @@ html {
 
   .section-heading {
     font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
-    font-size: clamp(2rem, 1.54rem + 1.7vw, 3.25rem);
+    font-size: clamp(1.75rem, 1.38rem + 1.18vw, 2.6rem);
     line-height: 1.08;
     color: var(--ink-950);
     text-wrap: balance;

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -15,7 +15,7 @@ export default function ContactCTA() {
             <p className="inline-flex rounded-full border border-[#d8c2a6] bg-white/80 px-4 py-1.5 text-[0.66rem] font-semibold uppercase tracking-[0.2em] text-[var(--brand-copper-deep)]">
               {brand.name}
             </p>
-            <h2 className="section-heading">{brand.tagline}</h2>
+            <h2 className="section-subheading">{brand.tagline}</h2>
             <p className="section-body">
               Coordinemos una entrevista inicial para conocer la situacion de
               cada estudiante y definir un plan de acompanamiento realista,

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -14,10 +14,10 @@ export default function Hero() {
         <div className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
           <div className="space-y-8">
             <div className="space-y-5">
-              <h1 className="text-3xl font-semibold uppercase tracking-[0.25em] text-[#B88A3B] sm:text-4xl lg:text-5xl">
+              <h1 className="text-4xl font-semibold uppercase tracking-[0.28em] text-[#B88A3B] sm:text-5xl lg:text-6xl">
                 {hero.title}
               </h1>
-              <h2 className="section-heading max-w-2xl">
+              <h2 className="section-subheading max-w-2xl">
                 {hero.subtitle}
               </h2>
               <p className="section-body max-w-2xl">
@@ -33,12 +33,6 @@ export default function Hero() {
                 className={buttonVariants({ variant: "primary", fullWidth: true })}
               >
                 {primaryCta.label}
-              </a>
-              <a
-                href="#contacto"
-                className={buttonVariants({ variant: "secondary", fullWidth: true })}
-              >
-                Coordinar entrevista inicial
               </a>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy so the brand `INGENIUM` reads as the primary element and descriptive lines like “Acompañamiento educativo” or “Acompañamiento para organizarse por dentro” are visually subordinate. 
- Remove the redundant secondary CTA in the hero to simplify the interaction and direct users to the primary action.
- Reduce oversized section titles site-wide to avoid headings overpowering brand elements.

### Description
- Increased the hero brand headline size and tracking by updating the hero `h1` classes in `components/sections/Hero.tsx` to `text-4xl ... sm:text-5xl lg:text-6xl` and `tracking-[0.28em]`.
- Demoted the hero subtitle from `section-heading` to `section-subheading` in `components/sections/Hero.tsx` so `Acompañamiento educativo` is visually subordinate to `INGENIUM`.
- Removed the secondary hero CTA link (`Coordinar entrevista inicial`) from `components/sections/Hero.tsx` to leave only the primary CTA.
- Reduced the global `.section-heading` scale in `app/globals.css` by changing the `font-size` clamp to `clamp(1.75rem, 1.38rem + 1.18vw, 2.6rem)` to prevent excessively large titles across the site.
- Changed the contact section tagline to use `section-subheading` instead of `section-heading` in `components/sections/ContactCTA.tsx` so the brand label remains the visual anchor.

### Testing
- Ran `npm run lint` and it completed successfully without errors.
- Started the dev server (`next dev`) as part of validation and captured a full-page screenshot via Playwright; the first Playwright attempt timed out but a second run succeeded and produced `artifacts/hero-contact-updated.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699715884f30832d9bc68be7fbd1fcc2)