### PR TITLE
Ajusta jerarquía visual de INGENIUM y reduce tamaño de títulos

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -255,6 +255,14 @@ html {
     text-wrap: pretty;
   }
 
+  .card-heading {
+    font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+    font-size: clamp(1.12rem, 1.02rem + 0.55vw, 1.58rem);
+    line-height: 1.22;
+    color: var(--ink-900);
+    text-wrap: pretty;
+  }
+
   .section-body {
     font-size: clamp(1.02rem, 0.97rem + 0.22vw, 1.18rem);
     line-height: 1.8;

--- a/app/globals.css
+++ b/app/globals.css
@@ -241,7 +241,7 @@ html {
 
   .section-heading {
     font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
-    font-size: clamp(2rem, 1.54rem + 1.7vw, 3.25rem);
+    font-size: clamp(1.7rem, 1.35rem + 1.2vw, 2.55rem);
     line-height: 1.08;
     color: var(--ink-950);
     text-wrap: balance;

--- a/components/sections/Audience.tsx
+++ b/components/sections/Audience.tsx
@@ -37,7 +37,7 @@ export default function Audience() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <h3 className="section-subheading">
+                  <h3 className="card-heading">
                     {item.title}
                   </h3>
                   <p className="section-secondary">

--- a/components/sections/ContactCTA.tsx
+++ b/components/sections/ContactCTA.tsx
@@ -12,10 +12,10 @@ export default function ContactCTA() {
       <div className="section-shell">
         <div className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-start">
           <div className="space-y-6">
-            <p className="inline-flex rounded-full border border-[#d8c2a6] bg-white/80 px-4 py-1.5 text-[0.66rem] font-semibold uppercase tracking-[0.2em] text-[var(--brand-copper-deep)]">
+            <p className="inline-flex rounded-full border border-[#d8c2a6] bg-white/80 px-4 py-1.5 text-[0.74rem] font-semibold uppercase tracking-[0.24em] text-[var(--brand-copper-deep)]">
               {brand.name}
             </p>
-            <h2 className="section-heading">{brand.tagline}</h2>
+            <h2 className="section-subheading max-w-2xl">{brand.tagline}</h2>
             <p className="section-body">
               Coordinemos una entrevista inicial para conocer la situacion de
               cada estudiante y definir un plan de acompanamiento realista,

--- a/components/sections/ExamsSection.tsx
+++ b/components/sections/ExamsSection.tsx
@@ -16,7 +16,7 @@ export default function ExamsSection() {
           <div className="grid gap-6 lg:grid-cols-1">
             {section.items?.map((item) => (
               <Card key={item.title} className="flex h-full flex-col gap-4 text-left">
-                <h3 className="section-subheading">{item.title}</h3>
+                <h3 className="card-heading">{item.title}</h3>
                 <div className="space-y-3 section-secondary">
                   {item.list ? (
                     <div className="space-y-2">

--- a/components/sections/FaqSection.tsx
+++ b/components/sections/FaqSection.tsx
@@ -15,7 +15,7 @@ export default function FaqSection() {
           <div className="grid gap-6 md:grid-cols-2">
             {section.items?.map((item) => (
               <Card key={item.title} className="flex h-full flex-col gap-3 text-left">
-                <h3 className="section-subheading">{item.title}</h3>
+                <h3 className="card-heading">{item.title}</h3>
                 <p className="section-secondary">{item.body}</p>
               </Card>
             ))}

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -14,10 +14,10 @@ export default function Hero() {
         <div className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
           <div className="space-y-8">
             <div className="space-y-5">
-              <h1 className="text-3xl font-semibold uppercase tracking-[0.25em] text-[#B88A3B] sm:text-4xl lg:text-5xl">
+              <h1 className="text-4xl font-semibold uppercase tracking-[0.25em] text-[#B88A3B] sm:text-5xl lg:text-6xl">
                 {hero.title}
               </h1>
-              <h2 className="section-heading max-w-2xl">
+              <h2 className="section-subheading max-w-2xl">
                 {hero.subtitle}
               </h2>
               <p className="section-body max-w-2xl">
@@ -33,12 +33,6 @@ export default function Hero() {
                 className={buttonVariants({ variant: "primary", fullWidth: true })}
               >
                 {primaryCta.label}
-              </a>
-              <a
-                href="#contacto"
-                className={buttonVariants({ variant: "secondary", fullWidth: true })}
-              >
-                Coordinar entrevista inicial
               </a>
             </div>
           </div>

--- a/components/sections/HowWeWork.tsx
+++ b/components/sections/HowWeWork.tsx
@@ -26,7 +26,7 @@ export default function HowWeWork() {
                   className={index === 1 ? "bg-[#f5e2c7]" : undefined}
                 />
                 <div className="space-y-3">
-                  <h3 className="section-subheading">
+                  <h3 className="card-heading">
                     {item.title}
                   </h3>
                   <p className="section-secondary">

--- a/components/sections/ProposalsSection.tsx
+++ b/components/sections/ProposalsSection.tsx
@@ -16,7 +16,7 @@ export default function ProposalsSection() {
           <div className="grid gap-6 lg:grid-cols-3">
             {section.items?.map((item) => (
               <Card key={item.title} className="flex h-full flex-col gap-4 text-left">
-                <h3 className="section-subheading">{item.title}</h3>
+                <h3 className="card-heading">{item.title}</h3>
                 <div className="space-y-3 section-secondary">
                   {item.meta?.map((metaItem) => (
                     <p key={metaItem.label}>

--- a/components/sections/SupportSection.tsx
+++ b/components/sections/SupportSection.tsx
@@ -29,7 +29,7 @@ export default function SupportSection() {
                   className={index % 2 === 1 ? "bg-[linear-gradient(160deg,#f6e5cb,#efd6b1)]" : undefined}
                 />
                 <div className="space-y-3">
-                  <h3 className="section-subheading">
+                  <h3 className="card-heading">
                     {item.title}
                   </h3>
                   <p className="section-secondary">


### PR DESCRIPTION
### Motivation
- Mejorar la jerarquía visual del hero para que el nombre de marca `INGENIUM` tenga más protagonismo frente al subtítulo y evitar que el subtítulo parezca más importante que la marca.
- Eliminar acciones redundantes en el hero para centrar la atención en la CTA principal (WhatsApp).
- Reducir la escala de los títulos globales para que los encabezados no dominen visualmente las secciones secundarias.
- Ajustar la sección de contacto para reforzar la presencia de la marca y subordininar el tagline.

### Description
- Incrementé el tamaño del `h1` del hero pasando de `text-3xl sm:text-4xl lg:text-5xl` a `text-4xl sm:text-5xl lg:text-6xl` para dar más peso a `INGENIUM` en `components/sections/Hero.tsx`.
- Cambié el subtítulo del hero y el tagline de la sección de contacto a usar la clase `section-subheading` en lugar de `section-heading` para que queden visualmente subordinados en `Hero.tsx` y `ContactCTA.tsx`.
- Eliminé el botón secundario `Coordinar entrevista inicial` del hero, dejando solo la CTA principal de WhatsApp en `components/sections/Hero.tsx`.
- Reduje la regla global de tamaños de `.section-heading` en `app/globals.css` para bajar la escala base de los títulos en todo el sitio.

### Testing
- Ejecuté `npm run lint` y la verificación de ESLint completó correctamente (éxito).
- Inicié el servidor de desarrollo con `npm run dev` y la aplicación respondió en `http://localhost:3000` (arranque exitoso).
- Tomé una captura de la página con Playwright; el primer intento falló por timeout y el segundo intento generó la captura correctamente (captura disponible en los artefactos).
- No se realizaron cambios en otras rutas ni en la lógica de negocio y no se observaron errores de compilación durante las pruebas locales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699715884f30832d9bc68be7fbd1fcc2)