### PR TITLE
Fix mobile rendering of support section CTA button

### DIFF
--- a/components/sections/SupportSection.tsx
+++ b/components/sections/SupportSection.tsx
@@ -43,7 +43,12 @@ export default function SupportSection() {
             <div className="flex justify-center">
               <a
                 href={cta.href}
-                className={buttonVariants({ variant: "secondary" })}
+                className={buttonVariants({
+                  variant: "secondary",
+                  fullWidth: true,
+                  className:
+                    "max-w-[56rem] whitespace-normal px-5 text-center leading-relaxed sm:whitespace-nowrap",
+                })}
               >
                 {cta.label}
               </a>


### PR DESCRIPTION
### Motivation
- The CTA "Contanos tu situación y te decimos cuál es el mejor camino." was getting cut off on small screens and needed to wrap/read correctly on mobile while keeping the one-line look on larger viewports.

### Description
- Update the support section CTA in `components/sections/SupportSection.tsx` to use `buttonVariants` with `fullWidth: true` so the button can occupy available width on small screens.
- Add an explicit `className` to the CTA with `max-w-[56rem]`, `whitespace-normal`, `px-5`, `text-center`, and `leading-relaxed` while keeping `sm:whitespace-nowrap` to preserve single-line presentation on larger breakpoints.
- The change allows the long label to wrap on mobile and improves spacing and legibility without modifying other components.

### Testing
- Ran `npm run lint` which completed successfully with no lint errors.
- Attempted an automated Playwright check to capture a mobile screenshot, but the headless Chromium instance crashed with a `SIGSEGV` so the screenshot step failed; the code change itself is small and type-checked by the existing build toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997274d88ac832d8683af0b42145b2c)